### PR TITLE
feat(benchmark): implement benchmark tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,6 +2130,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "webpki-roots",
+ "zyn-client",
  "zyn-protocol",
  "zyn-util",
 ]
@@ -2146,6 +2147,7 @@ dependencies = [
  "serde_derive",
  "tokio",
  "tokio-rustls",
+ "tokio-stream",
  "tracing",
  "zyn-common",
  "zyn-protocol",

--- a/crates/benchmark/Cargo.toml
+++ b/crates/benchmark/Cargo.toml
@@ -27,5 +27,6 @@ rand = "0.9"
 futures = "0.3"
 
 # Internal dependencies
+zyn-client = { path = "../client" }
 zyn-protocol = { path = "../protocol" }
 zyn-util = { path = "../util" }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -9,6 +9,7 @@ async-trait = "0.1.88"
 humantime-serde = "1.1"
 tokio = { version = "1.48.0", features = ["io-util", "net"] }
 tokio-rustls = "0.26.4"
+tokio-stream = "0.1"
 tracing = "0.1.41"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_derive = "1.0.219"

--- a/crates/modulator/src/config.rs
+++ b/crates/modulator/src/config.rs
@@ -277,9 +277,9 @@ pub struct Limits {
   /// The maximum number of inflight requests per client.
   pub max_inflight_requests: u32,
 
-  /// The maximum number of messages that can be enqueued
+  /// The maximum number of outbound messages that can be enqueued
   /// before disconnecting the client.
-  pub send_message_channel_size: u32,
+  pub outgoing_message_queue_size: u32,
 
   /// The maximum number of messages that will be batched
   /// after serialization before flushing to the client.
@@ -299,7 +299,7 @@ impl Default for Limits {
       max_payload_size: 256 * 1024,                  // 256KB
       payload_pool_memory_budget: 256 * 1024 * 1024, // 256MB
       max_inflight_requests: 100,
-      send_message_channel_size: 512,
+      outgoing_message_queue_size: 2048,
       flush_batch_size: 64,
       rate_limit: 512 * 1024, // 512KB
     }
@@ -316,7 +316,7 @@ impl From<&ServerConfig> for zyn_common::conn::Config {
       connect_timeout: config.connect_timeout,
       authenticate_timeout: Default::default(),
       payload_read_timeout: config.payload_read_timeout,
-      send_message_channel_size: config.limits.send_message_channel_size,
+      outbound_message_queue_size: config.limits.outgoing_message_queue_size,
       request_timeout: config.request_timeout,
       max_inflight_requests: config.limits.max_inflight_requests,
       flush_batch_size: config.limits.flush_batch_size,

--- a/crates/modulator/src/listener.rs
+++ b/crates/modulator/src/listener.rs
@@ -261,9 +261,6 @@ where
     tcp_stream: tokio::net::TcpStream,
     conn_mng: zyn_common::conn::ConnManager<D, DF, ST>,
   ) -> anyhow::Result<()> {
-    // Set the TCP_NODELAY option to disable Nagle's algorithm.
-    tcp_stream.set_nodelay(true)?;
-
     conn_mng.run(Stream::Tcp(tcp_stream)).await?;
 
     Ok(())

--- a/crates/protocol/src/error.rs
+++ b/crates/protocol/src/error.rs
@@ -32,7 +32,7 @@ pub enum ErrorReason {
   /// The server is in the process of shutting down and not accepting new requests.
   ServerShuttingDown,
   /// The message channel buffer is full and cannot accept new messages.
-  MessageChannelIsFull,
+  OutboundQueueIsFull,
   /// The requested operation is not allowed for the current user or context.
   NotAllowed,
   /// The requested feature or operation is not yet implemented.
@@ -74,7 +74,7 @@ impl From<ErrorReason> for &str {
       ErrorReason::PolicyViolation => "POLICY_VIOLATION",
       ErrorReason::ServerOverloaded => "SERVER_OVERLOADED",
       ErrorReason::ServerShuttingDown => "SERVER_SHUTTING_DOWN",
-      ErrorReason::MessageChannelIsFull => "MESSAGE_CHANNEL_FULL",
+      ErrorReason::OutboundQueueIsFull => "OUTBOUND_QUEUE_FULL",
       ErrorReason::NotAllowed => "NOT_ALLOWED",
       ErrorReason::NotImplemented => "NOT_IMPLEMENTED",
       ErrorReason::Timeout => "TIMEOUT",
@@ -107,14 +107,14 @@ impl FromStr for ErrorReason {
       "CHANNEL_IS_FULL" => Ok(ErrorReason::ChannelIsFull),
       "INTERNAL_SERVER_ERROR" => Ok(ErrorReason::InternalServerError),
       "FORBIDDEN" => Ok(ErrorReason::Forbidden),
-      "MESSAGE_CHANNEL_FULL" => Ok(ErrorReason::MessageChannelIsFull),
+      "OUTBOUND_QUEUE_FULL" => Ok(ErrorReason::OutboundQueueIsFull),
       "NONE" => Ok(ErrorReason::None),
       "NOT_ALLOWED" => Ok(ErrorReason::NotAllowed),
       "NOT_IMPLEMENTED" => Ok(ErrorReason::NotImplemented),
       "POLICY_VIOLATION" => Ok(ErrorReason::PolicyViolation),
       "SERVER_OVERLOADED" => Ok(ErrorReason::ServerOverloaded),
       "SERVER_SHUTTING_DOWN" => Ok(ErrorReason::ServerShuttingDown),
-      "SEND_CHANNEL_FULL" => Ok(ErrorReason::MessageChannelIsFull),
+      "SEND_CHANNEL_FULL" => Ok(ErrorReason::OutboundQueueIsFull),
       "TIMEOUT" => Ok(ErrorReason::Timeout),
       "UNAUTHORIZED" => Ok(ErrorReason::Unauthorized),
       "UNEXPECTED_MESSAGE" => Ok(ErrorReason::UnexpectedMessage),

--- a/crates/server/src/c2s/config.rs
+++ b/crates/server/src/c2s/config.rs
@@ -162,10 +162,10 @@ pub struct Limits {
   #[serde(default = "default_max_inflight_requests")]
   pub max_inflight_requests: u32,
 
-  /// The maximum number of messages that can be enqueued
+  /// The maximum number of outgoing messages that can be enqueued
   /// before disconnecting the client.
-  #[serde(default = "default_send_message_channel_size")]
-  pub send_message_channel_size: u32,
+  #[serde(default = "default_outbound_message_queue_size")]
+  pub outbound_message_queue_size: u32,
 
   /// The maximum number of messages that will be batched
   /// after serialization before flushing to the client.
@@ -205,8 +205,8 @@ fn default_max_channels_per_client() -> u32 {
   100
 }
 
-fn default_send_message_channel_size() -> u32 {
-  1_024
+fn default_outbound_message_queue_size() -> u32 {
+  2048
 }
 
 fn default_flush_batch_size() -> u32 {
@@ -231,7 +231,7 @@ impl Default for Limits {
       max_message_size: default_max_message_size(),
       max_payload_size: default_max_payload_size(),
       max_inflight_requests: default_max_inflight_requests(),
-      send_message_channel_size: default_send_message_channel_size(),
+      outbound_message_queue_size: default_outbound_message_queue_size(),
       flush_batch_size: default_flush_batch_size(),
       rate_limit: default_rate_limit(),
       payload_pool_memory_budget: default_payload_pool_memory_budget(),
@@ -248,7 +248,7 @@ impl From<&Config> for zyn_common::conn::Config {
       connect_timeout: config.connect_timeout,
       authenticate_timeout: config.authenticate_timeout,
       payload_read_timeout: config.payload_read_timeout,
-      send_message_channel_size: config.limits.send_message_channel_size,
+      outbound_message_queue_size: config.limits.outbound_message_queue_size,
       request_timeout: config.request_timeout,
       max_inflight_requests: config.limits.max_inflight_requests,
       flush_batch_size: config.limits.flush_batch_size,

--- a/crates/server/src/c2s/conn.rs
+++ b/crates/server/src/c2s/conn.rs
@@ -30,7 +30,7 @@ use zyn_util::string_atom::StringAtom;
 pub type C2sConnManager = zyn_common::conn::ConnManager<C2sDispatcher, C2sDispatcherFactory, C2sService>;
 
 #[derive(Clone)]
-/// A transmitter implementation for C2S (client-to-server) connections.
+/// A transmitter implementation for C2S connections.
 ///
 /// This struct wraps a connection transmitter (`ConnTx`) along with the handler
 /// identifier to provide a `Transmitter` interface for C2S connections.

--- a/crates/server/src/c2s/listener.rs
+++ b/crates/server/src/c2s/listener.rs
@@ -216,9 +216,6 @@ async fn handle_connection(
   acceptor: TlsAcceptor,
   conn_mng: C2sConnManager,
 ) -> anyhow::Result<()> {
-  // Set the TCP_NODELAY option to disable Nagle's algorithm.
-  tcp_stream.set_nodelay(true)?;
-
   // Negotiate the TLS connection.
   let tls_stream = acceptor.accept(tcp_stream).await?;
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -202,18 +202,18 @@ async fn wait_for_stop_signal() -> anyhow::Result<()> {
 }
 
 fn set_file_descriptor_limit(max_connections: u32) -> anyhow::Result<()> {
-  // Calculate desired fd limit: max_connections + cluster_overhead (25% of max) + 32 (internal usage)
-  let cluster_overhead = max_connections / 4; // 25% overhead for cluster operations
-  let desired_fd_limit = max_connections + cluster_overhead + 32;
+  // Calculate desired fd limit: max_connections + overhead (25% of max) + 32 (internal usage)
+  let overhead = max_connections / 4; // 25% overhead
+  let desired_fd_limit = max_connections + overhead + 32;
 
-  let (_soft, hard) = rlimit::getrlimit(Resource::NOFILE)?;
+  let (soft, hard) = rlimit::getrlimit(Resource::NOFILE)?;
 
-  let new_limit = std::cmp::min(desired_fd_limit as u64, hard);
+  let new_soft_limit = std::cmp::min(desired_fd_limit as u64, hard);
 
-  rlimit::setrlimit(Resource::NOFILE, new_limit, hard)
+  rlimit::setrlimit(Resource::NOFILE, new_soft_limit, hard)
     .map_err(|err| anyhow::anyhow!("failed to set file descriptor limit: {}", err))?;
 
-  info!(new_limit, "set file descriptor limit");
+  info!(new_soft_limit, soft_limit = soft, hard_limit = hard, "set file descriptor limit");
 
   Ok(())
 }

--- a/crates/test-util/src/c2s_suite.rs
+++ b/crates/test-util/src/c2s_suite.rs
@@ -106,7 +106,7 @@ impl C2sSuite {
       connect_timeout: arc_config.connect_timeout,
       authenticate_timeout: arc_config.authenticate_timeout,
       payload_read_timeout: arc_config.payload_read_timeout,
-      send_message_channel_size: arc_config.limits.send_message_channel_size,
+      outbound_message_queue_size: arc_config.limits.outbound_message_queue_size,
       request_timeout: arc_config.request_timeout,
       max_inflight_requests: arc_config.limits.max_inflight_requests,
       flush_batch_size: arc_config.limits.flush_batch_size,

--- a/examples/config/c2s-benchmark.toml
+++ b/examples/config/c2s-benchmark.toml
@@ -1,0 +1,16 @@
+# This configuration file is designed for benchmarking Zyn's C2S performance.
+
+# Enable console logging for telemetry
+# [telemetry.console]
+# enabled = true
+
+[c2s-server.limits]
+# Maximum number of clients allowed per channel.
+max_clients_per_channel = 5000
+
+# When running benchmarks locally, set the outbound message queue size to a high value
+# to prevent disconnects due to outbound queue overflow.
+outbound_message_queue_size = 262144
+
+# Disable rate limiting completely to prevent artificial throughput caps.
+rate_limit = 0


### PR DESCRIPTION
Add a benchmark tool to measure messaging performance. The tool simulates configurable producer/consumer clients, measures throughput and latency metrics, and supports customizable payload sizes and test durations.