### PR TITLE
feat: dynamic fd limits based on config limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,6 +1252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlimit"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,6 +2222,7 @@ dependencies = [
  "console-subscriber",
  "parking_lot",
  "rcgen",
+ "rlimit",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -30,6 +30,7 @@ zyn-common = { path = "../common" }
 zyn-modulator = { path = "../modulator" }
 zyn-protocol = { path = "../protocol" }
 zyn-util = { path = "../util" }
+rlimit = "0.10.2"
 
 [dev-dependencies]
 pki-types = { package = "rustls-pki-types", version = "1" }


### PR DESCRIPTION
Replaces hardcoded `RLIMIT_NOFILE` with formula-based calculation:
- Uses max_connections + 25% overhead + 32
- Respects system hard limits