### PR TITLE
feat(protocol): allow `/` character in channel handler names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to Narwhal will be documented in this file.
 
 ## Unreleased
 
-* [ENHANCEMENT]: Allow `/` character in channel handler names for hierarchical naming.
 * [CHANGE]: Migrate async runtime from monoio to compio (io_uring). [#212](https://github.com/narwhal-io/narwhal/pull/212)
 * [ENHANCEMENT]: Add channel persistence support. [#184](https://github.com/narwhal-io/narwhal/pull/184), [#185](https://github.com/narwhal-io/narwhal/pull/185), [#191](https://github.com/narwhal-io/narwhal/pull/191), [#192](https://github.com/narwhal-io/narwhal/pull/192), [#193](https://github.com/narwhal-io/narwhal/pull/193), [#198](https://github.com/narwhal-io/narwhal/pull/198), [#199](https://github.com/narwhal-io/narwhal/pull/199), [#201](https://github.com/narwhal-io/narwhal/pull/201), [#204](https://github.com/narwhal-io/narwhal/pull/204), [#205](https://github.com/narwhal-io/narwhal/pull/205), [#208](https://github.com/narwhal-io/narwhal/pull/208), [#217](https://github.com/narwhal-io/narwhal/pull/217)
 * [ENHANCEMENT]: Abstract runtime behind `Runtime` trait for future multi-runtime support. [#210](https://github.com/narwhal-io/narwhal/pull/210)
 * [ENHANCEMENT]: Add Prometheus metrics support. [#175](https://github.com/narwhal-io/narwhal/pull/175)
 * [ENHANCEMENT]: Extract thread and runtime management into a shared `CoreDispatcher`. [#172](https://github.com/narwhal-io/narwhal/pull/172)
+* [ENHANCEMENT]: Allow `/` character in channel handler names for hierarchical naming. [#220](https://github.com/narwhal-io/narwhal/pull/220)
 
 ## 0.5.0 (2026-03-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Narwhal will be documented in this file.
 
 ## Unreleased
 
+* [ENHANCEMENT]: Allow `/` character in channel handler names for hierarchical naming.
 * [CHANGE]: Migrate async runtime from monoio to compio (io_uring). [#212](https://github.com/narwhal-io/narwhal/pull/212)
 * [ENHANCEMENT]: Add channel persistence support. [#184](https://github.com/narwhal-io/narwhal/pull/184), [#185](https://github.com/narwhal-io/narwhal/pull/185), [#191](https://github.com/narwhal-io/narwhal/pull/191), [#192](https://github.com/narwhal-io/narwhal/pull/192), [#193](https://github.com/narwhal-io/narwhal/pull/193), [#198](https://github.com/narwhal-io/narwhal/pull/198), [#199](https://github.com/narwhal-io/narwhal/pull/199), [#201](https://github.com/narwhal-io/narwhal/pull/201), [#204](https://github.com/narwhal-io/narwhal/pull/204), [#205](https://github.com/narwhal-io/narwhal/pull/205), [#208](https://github.com/narwhal-io/narwhal/pull/208), [#217](https://github.com/narwhal-io/narwhal/pull/217)
 * [ENHANCEMENT]: Abstract runtime behind `Runtime` trait for future multi-runtime support. [#210](https://github.com/narwhal-io/narwhal/pull/210)

--- a/crates/protocol/src/id.rs
+++ b/crates/protocol/src/id.rs
@@ -119,7 +119,7 @@ impl ChannelId {
     if handler.is_empty() || handler.len() > CHANNEL_HANDLER_MAX_LENGTH {
       return false;
     }
-    if !handler.chars().all(|c| c.is_alphanumeric() || c == '/') {
+    if !handler.chars().all(|c| c.is_ascii_alphanumeric() || c == '/') {
       return false;
     }
 

--- a/crates/protocol/src/id.rs
+++ b/crates/protocol/src/id.rs
@@ -119,7 +119,7 @@ impl ChannelId {
     if handler.is_empty() || handler.len() > CHANNEL_HANDLER_MAX_LENGTH {
       return false;
     }
-    if !handler.chars().all(|c| c.is_alphanumeric()) {
+    if !handler.chars().all(|c| c.is_alphanumeric() || c == '/') {
       return false;
     }
 
@@ -348,6 +348,12 @@ mod tests {
     assert_eq!(channel_id.handler.as_ref(), "test");
     assert_eq!(channel_id.domain.as_ref(), "localhost");
     assert_eq!(channel_id.to_string(), "!test@localhost");
+
+    // Test with slash in handler
+    let channel_id = ChannelId::from_str("!sports/football@example.com").unwrap();
+    assert_eq!(channel_id.handler.as_ref(), "sports/football");
+    assert_eq!(channel_id.domain.as_ref(), "example.com");
+    assert_eq!(channel_id.to_string(), "!sports/football@example.com");
   }
 
   #[test]

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -275,8 +275,8 @@ A NID is a unique identifier for users and servers in the format `username@domai
 A ChannelId identifies a communication channel in the format `!handler@domain`.
 
 - Format: `!{handler}@{domain}` (e.g., `!abc123@example.com`)
-- Handler is a non-empty alphanumeric string (up to 256 characters)
-- Handler must contain only alphanumeric characters (a-z, A-Z, 0-9)
+- Handler is a non-empty string (up to 256 characters)
+- Handler must contain only alphanumeric characters (a-z, A-Z, 0-9) or forward slashes (`/`)
 - Domain follows the same validation rules as NID domains
 
 ### Access Control Lists (ACLs)
@@ -1119,7 +1119,7 @@ Forwards a broadcast message payload to the modulator for application-specific v
 **Parameters**:
 - `id` (u32, required): Request identifier (must be non-zero)
 - `from` (string, required): Sender NID (must be non-empty)
-- `channel` (string, required): Channel handler (must be non-empty, alphanumeric)
+- `channel` (string, required): Channel handler (must be non-empty, alphanumeric or `/`)
 - `length` (u32, required): Payload size in bytes (must be non-zero)
 
 **Example**:


### PR DESCRIPTION
This enables hierarchical channel naming (e.g. sports/football).