### PR TITLE
docs: drop "Last updated" header from architecture specs

### DIFF
--- a/docs/architecture/ACTOR_SHARDING.md
+++ b/docs/architecture/ACTOR_SHARDING.md
@@ -1,7 +1,6 @@
 # Actor-Based Sharding — Architecture Specification
 
 > **Status:** Implemented.
-> **Last updated:** 2026-04-17
 
 ## Table of Contents
 

--- a/docs/architecture/CHANNEL_STORE.md
+++ b/docs/architecture/CHANNEL_STORE.md
@@ -1,7 +1,6 @@
 # Channel Store — Architecture Specification
 
 > **Status:** Implemented.
-> **Last updated:** 2026-04-17
 > **Related PRs:** see `crates/server/src/channel/file_store.rs` history.
 
 ## Table of Contents

--- a/docs/architecture/MESSAGE_LOG.md
+++ b/docs/architecture/MESSAGE_LOG.md
@@ -1,7 +1,6 @@
 # Message Log — Architecture Specification
 
 > **Status:** Implemented.
-> **Last updated:** 2026-04-16
 > **Related PRs:** [#221](https://github.com/narwhal-io/narwhal/pull/221) (HISTORY/CHAN_SEQ protocol), [#227](https://github.com/narwhal-io/narwhal/pull/227) (FileMessageLog implementation)
 
 ## Table of Contents


### PR DESCRIPTION
## Summary
- Removes the manually maintained `Last updated: YYYY-MM-DD` line from the header block of `MESSAGE_LOG.md`, `CHANNEL_STORE.md`, and `ACTOR_SHARDING.md`.
- Git history is the source of truth for dates; a manually maintained field rots and silently lies to readers once someone edits the doc without bumping it.
