### PR TITLE
feat(server): instrument channel persistence with Prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Narwhal will be documented in this file.
 * [CHANGE]: Migrate async runtime from monoio to compio (io_uring). [#212](https://github.com/narwhal-io/narwhal/pull/212)
 * [ENHANCEMENT]: Add channel persistence support. [#184](https://github.com/narwhal-io/narwhal/pull/184), [#185](https://github.com/narwhal-io/narwhal/pull/185), [#191](https://github.com/narwhal-io/narwhal/pull/191), [#192](https://github.com/narwhal-io/narwhal/pull/192), [#193](https://github.com/narwhal-io/narwhal/pull/193), [#198](https://github.com/narwhal-io/narwhal/pull/198), [#199](https://github.com/narwhal-io/narwhal/pull/199), [#201](https://github.com/narwhal-io/narwhal/pull/201), [#204](https://github.com/narwhal-io/narwhal/pull/204), [#205](https://github.com/narwhal-io/narwhal/pull/205), [#208](https://github.com/narwhal-io/narwhal/pull/208), [#217](https://github.com/narwhal-io/narwhal/pull/217), [#221](https://github.com/narwhal-io/narwhal/pull/221), [#222](https://github.com/narwhal-io/narwhal/pull/222), [#227](https://github.com/narwhal-io/narwhal/pull/227)
 * [ENHANCEMENT]: Abstract runtime behind `Runtime` trait for future multi-runtime support. [#210](https://github.com/narwhal-io/narwhal/pull/210)
-* [ENHANCEMENT]: Add Prometheus metrics support. [#175](https://github.com/narwhal-io/narwhal/pull/175)
+* [ENHANCEMENT]: Add Prometheus metrics support. [#175](https://github.com/narwhal-io/narwhal/pull/175), [#234](https://github.com/narwhal-io/narwhal/pull/234)
 * [ENHANCEMENT]: Extract thread and runtime management into a shared `CoreDispatcher`. [#172](https://github.com/narwhal-io/narwhal/pull/172)
 * [ENHANCEMENT]: Allow `/` character in channel handler names for hierarchical naming. [#220](https://github.com/narwhal-io/narwhal/pull/220)
 

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 use std::fs as std_fs; // only for read_dir (no compio equivalent)
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Instant;
 
 use async_trait::async_trait;
 use compio::BufResult;
@@ -12,6 +13,9 @@ use memmap2::{Mmap, MmapMut};
 use narwhal_protocol::{Message, NID_MAX_LENGTH};
 use narwhal_util::pool::PoolBuffer;
 use narwhal_util::string_atom::StringAtom;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::histogram::Histogram;
+use prometheus_client::registry::Registry;
 
 use super::file_store::channel_hash;
 use super::store::{LogEntry, LogVisitor, MessageLog, MessageLogFactory};
@@ -38,6 +42,77 @@ const SEGMENT_EXT: &str = "log";
 /// Index file extension.
 const INDEX_EXT: &str = "idx";
 
+/// Metric handles for `FileMessageLog` operations.
+///
+/// Cloneable — each `FileMessageLog` instance holds a clone, so a single set of
+/// handles is shared across all logs created by a factory.
+#[derive(Clone)]
+pub struct MessageLogMetrics {
+  recovery_duration_seconds: Histogram,
+  append_duration_seconds: Histogram,
+  segments_rolled: Counter,
+  segments_evicted: Counter,
+  evicted_bytes: Counter,
+  crc_failures: Counter,
+}
+
+impl std::fmt::Debug for MessageLogMetrics {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("MessageLogMetrics").finish_non_exhaustive()
+  }
+}
+
+impl MessageLogMetrics {
+  /// Registers the metric handles on `registry` and returns them.
+  pub fn register(registry: &mut Registry) -> Self {
+    let recovery_duration_seconds =
+      Histogram::new(prometheus_client::metrics::histogram::exponential_buckets(0.001, 2.0, 16));
+    registry.register(
+      "message_log_recovery_duration_seconds",
+      "Duration of message log recovery at startup in seconds",
+      recovery_duration_seconds.clone(),
+    );
+    let append_duration_seconds =
+      Histogram::new(prometheus_client::metrics::histogram::exponential_buckets(0.0001, 2.0, 16));
+    registry.register(
+      "message_log_append_duration_seconds",
+      "Duration of message log append operations in seconds",
+      append_duration_seconds.clone(),
+    );
+    let segments_rolled = Counter::default();
+    registry.register("message_log_segments_rolled", "Message log segment rolls", segments_rolled.clone());
+    let segments_evicted = Counter::default();
+    registry.register("message_log_segments_evicted", "Message log segments evicted", segments_evicted.clone());
+    let evicted_bytes = Counter::default();
+    registry.register("message_log_evicted_bytes", "Bytes reclaimed by message log eviction", evicted_bytes.clone());
+    let crc_failures = Counter::default();
+    registry.register(
+      "message_log_crc_failures",
+      "Message log entries rejected due to CRC mismatch",
+      crc_failures.clone(),
+    );
+
+    Self { recovery_duration_seconds, append_duration_seconds, segments_rolled, segments_evicted, evicted_bytes, crc_failures }
+  }
+
+  /// Returns an instance with unregistered handles — useful for tests that do
+  /// not care about observing metric values.
+  pub fn noop() -> Self {
+    Self {
+      recovery_duration_seconds: Histogram::new(
+        prometheus_client::metrics::histogram::exponential_buckets(0.001, 2.0, 16),
+      ),
+      append_duration_seconds: Histogram::new(
+        prometheus_client::metrics::histogram::exponential_buckets(0.0001, 2.0, 16),
+      ),
+      segments_rolled: Counter::default(),
+      segments_evicted: Counter::default(),
+      evicted_bytes: Counter::default(),
+      crc_failures: Counter::default(),
+    }
+  }
+}
+
 /// Reusable, zero-allocation entry reader for the message log.
 ///
 /// Pre-allocates header and body buffers once at construction.  Buffers are
@@ -55,10 +130,13 @@ struct EntryReader {
   from_len: usize,
   payload_len: usize,
   entry_size: u64,
+
+  /// Counter incremented whenever `read_at` detects a CRC mismatch.
+  crc_failures: Counter,
 }
 
 impl EntryReader {
-  fn new(max_payload_size: u32) -> Self {
+  fn new(max_payload_size: u32, crc_failures: Counter) -> Self {
     Self {
       header: Vec::with_capacity(ENTRY_HEADER_SIZE),
       body: Vec::with_capacity(NID_MAX_LENGTH + max_payload_size as usize + CRC_SIZE),
@@ -67,6 +145,7 @@ impl EntryReader {
       from_len: 0,
       payload_len: 0,
       entry_size: 0,
+      crc_failures,
     }
   }
 
@@ -129,6 +208,7 @@ impl EntryReader {
     let computed_crc = hasher.finalize();
 
     if stored_crc != computed_crc {
+      self.crc_failures.inc();
       return false;
     }
 
@@ -209,17 +289,25 @@ struct Inner {
 
   /// Pre-allocated entry reader for the read path and recovery.
   reader: EntryReader,
+
+  /// Metric handles for operations performed by the log.
+  metrics: MessageLogMetrics,
 }
 
 // === impl FileMessageLog ===
 
 impl FileMessageLog {
   /// Create a new (or recover an existing) message log rooted at `channel_dir`.
-  async fn open(channel_dir: PathBuf, max_payload_size: u32) -> Self {
-    Self::open_with_segment_max(channel_dir, max_payload_size, SEGMENT_MAX_BYTES).await
+  async fn open(channel_dir: PathBuf, max_payload_size: u32, metrics: MessageLogMetrics) -> Self {
+    Self::open_with_segment_max(channel_dir, max_payload_size, SEGMENT_MAX_BYTES, metrics).await
   }
 
-  async fn open_with_segment_max(channel_dir: PathBuf, max_payload_size: u32, segment_max_bytes: u64) -> Self {
+  async fn open_with_segment_max(
+    channel_dir: PathBuf,
+    max_payload_size: u32,
+    segment_max_bytes: u64,
+    metrics: MessageLogMetrics,
+  ) -> Self {
     let mut inner = Inner {
       channel_dir,
       segment_max_bytes,
@@ -231,9 +319,12 @@ impl FileMessageLog {
       cached_first_seq: 0,
       cached_last_seq: 0,
       write_buf: Vec::with_capacity(ENTRY_HEADER_SIZE + NID_MAX_LENGTH + max_payload_size as usize + CRC_SIZE),
-      reader: EntryReader::new(max_payload_size),
+      reader: EntryReader::new(max_payload_size, metrics.crc_failures.clone()),
+      metrics,
     };
+    let start = Instant::now();
     inner.recover().await;
+    inner.metrics.recovery_duration_seconds.observe(start.elapsed().as_secs_f64());
     FileMessageLog { inner: RefCell::new(inner) }
   }
 }
@@ -604,6 +695,8 @@ impl Inner {
   }
 
   async fn roll_segment(&mut self, next_seq: u64) -> anyhow::Result<()> {
+    self.metrics.segments_rolled.inc();
+
     // Close the log file handle.
     self.active_log = None;
 
@@ -639,11 +732,12 @@ impl Inner {
 
     while self.segments.len() > 1 {
       if self.segments[0].last_seq < retain_from {
-        let first_seq = self.segments[0].first_seq;
         // Drop the segment (and its mmap) before deleting the underlying files.
-        self.segments.remove(0);
-        let _ = compio::fs::remove_file(self.segment_log_path(first_seq)).await;
-        let _ = compio::fs::remove_file(self.segment_idx_path(first_seq)).await;
+        let removed = self.segments.remove(0);
+        self.metrics.segments_evicted.inc();
+        self.metrics.evicted_bytes.inc_by(removed.file_size);
+        let _ = compio::fs::remove_file(self.segment_log_path(removed.first_seq)).await;
+        let _ = compio::fs::remove_file(self.segment_idx_path(removed.first_seq)).await;
       } else {
         break;
       }
@@ -695,6 +789,7 @@ impl Inner {
 impl MessageLog for FileMessageLog {
   async fn append(&self, message: &Message, payload: &PoolBuffer, max_messages: u32) -> anyhow::Result<()> {
     let inner = &mut *self.inner.borrow_mut();
+    let start = Instant::now();
 
     let params = match message {
       Message::Message(params) => params,
@@ -751,6 +846,7 @@ impl MessageLog for FileMessageLog {
     // Evict old segments if needed.
     inner.evict_segments(max_messages).await;
 
+    inner.metrics.append_duration_seconds.observe(start.elapsed().as_secs_f64());
     Ok(())
   }
 
@@ -893,19 +989,25 @@ pub struct FileMessageLogFactory {
   data_dir: Arc<PathBuf>,
   max_payload_size: u32,
   segment_max_bytes: Option<u64>,
+  metrics: MessageLogMetrics,
 }
 
 // === impl FileMessageLogFactory ===
 
 impl FileMessageLogFactory {
-  pub fn new(data_dir: PathBuf, max_payload_size: u32) -> Self {
-    Self { data_dir: Arc::new(data_dir), max_payload_size, segment_max_bytes: None }
+  pub fn new(data_dir: PathBuf, max_payload_size: u32, metrics: MessageLogMetrics) -> Self {
+    Self { data_dir: Arc::new(data_dir), max_payload_size, segment_max_bytes: None, metrics }
   }
 
   /// Creates a factory that produces logs with a custom segment size threshold.
   /// Useful for testing eviction without needing to fill 128 MiB segments.
-  pub fn with_segment_max(data_dir: PathBuf, max_payload_size: u32, segment_max_bytes: u64) -> Self {
-    Self { data_dir: Arc::new(data_dir), max_payload_size, segment_max_bytes: Some(segment_max_bytes) }
+  pub fn with_segment_max(
+    data_dir: PathBuf,
+    max_payload_size: u32,
+    segment_max_bytes: u64,
+    metrics: MessageLogMetrics,
+  ) -> Self {
+    Self { data_dir: Arc::new(data_dir), max_payload_size, segment_max_bytes: Some(segment_max_bytes), metrics }
   }
 }
 
@@ -917,8 +1019,10 @@ impl MessageLogFactory for FileMessageLogFactory {
     let hash = channel_hash(handler);
     let channel_dir = self.data_dir.join(hash.as_ref());
     match self.segment_max_bytes {
-      Some(max) => FileMessageLog::open_with_segment_max(channel_dir, self.max_payload_size, max).await,
-      None => FileMessageLog::open(channel_dir, self.max_payload_size).await,
+      Some(max) => {
+        FileMessageLog::open_with_segment_max(channel_dir, self.max_payload_size, max, self.metrics.clone()).await
+      },
+      None => FileMessageLog::open(channel_dir, self.max_payload_size, self.metrics.clone()).await,
     }
   }
 }
@@ -987,7 +1091,7 @@ mod tests {
 
   /// Helper: create a FileMessageLog in a temp directory.
   async fn create_log(dir: &std::path::Path) -> FileMessageLog {
-    let factory = FileMessageLogFactory::new(dir.to_path_buf(), TEST_MAX_PAYLOAD_SIZE);
+    let factory = FileMessageLogFactory::new(dir.to_path_buf(), TEST_MAX_PAYLOAD_SIZE, MessageLogMetrics::noop());
     factory.create(&StringAtom::from("test_channel")).await
   }
 
@@ -995,7 +1099,7 @@ mod tests {
   async fn create_log_with_segment_max(dir: &std::path::Path, segment_max_bytes: u64) -> FileMessageLog {
     let hash = channel_hash(&StringAtom::from("test_channel"));
     let channel_dir = dir.join(hash.as_ref());
-    FileMessageLog::open_with_segment_max(channel_dir, TEST_MAX_PAYLOAD_SIZE, segment_max_bytes).await
+    FileMessageLog::open_with_segment_max(channel_dir, TEST_MAX_PAYLOAD_SIZE, segment_max_bytes, MessageLogMetrics::noop()).await
   }
 
   /// Helper: append a single message with the given seq, from, and payload.
@@ -1530,7 +1634,7 @@ mod tests {
   #[compio::test]
   async fn test_factory_creates_independent_logs() {
     let tmp = tempfile::tempdir().unwrap();
-    let factory = FileMessageLogFactory::new(tmp.path().to_path_buf(), TEST_MAX_PAYLOAD_SIZE);
+    let factory = FileMessageLogFactory::new(tmp.path().to_path_buf(), TEST_MAX_PAYLOAD_SIZE, MessageLogMetrics::noop());
 
     let log_a = factory.create(&StringAtom::from("channel_a")).await;
     let log_b = factory.create(&StringAtom::from("channel_b")).await;

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -120,6 +120,20 @@ impl MessageLogMetrics {
   }
 }
 
+/// RAII guard that observes elapsed time on a `Histogram` when dropped.
+/// Ensures the histogram is updated on both `Ok` and `Err` paths without
+/// requiring every early return to record the observation explicitly.
+struct ObserveOnDrop {
+  histogram: Histogram,
+  start: Instant,
+}
+
+impl Drop for ObserveOnDrop {
+  fn drop(&mut self) {
+    self.histogram.observe(self.start.elapsed().as_secs_f64());
+  }
+}
+
 /// Reusable, zero-allocation entry reader for the message log.
 ///
 /// Pre-allocates header and body buffers once at construction.  Buffers are
@@ -702,8 +716,6 @@ impl Inner {
   }
 
   async fn roll_segment(&mut self, next_seq: u64) -> anyhow::Result<()> {
-    self.metrics.segments_rolled.inc();
-
     // Close the log file handle.
     self.active_log = None;
 
@@ -726,7 +738,9 @@ impl Inner {
     }
 
     // Create new segment.
-    self.create_segment(next_seq).await
+    self.create_segment(next_seq).await?;
+    self.metrics.segments_rolled.inc();
+    Ok(())
   }
 
   /// Evict oldest segments whose last_seq is entirely outside the retention window.
@@ -796,7 +810,7 @@ impl Inner {
 impl MessageLog for FileMessageLog {
   async fn append(&self, message: &Message, payload: &PoolBuffer, max_messages: u32) -> anyhow::Result<()> {
     let inner = &mut *self.inner.borrow_mut();
-    let start = Instant::now();
+    let _observe = ObserveOnDrop { histogram: inner.metrics.append_duration_seconds.clone(), start: Instant::now() };
 
     let params = match message {
       Message::Message(params) => params,
@@ -853,7 +867,6 @@ impl MessageLog for FileMessageLog {
     // Evict old segments if needed.
     inner.evict_segments(max_messages).await;
 
-    inner.metrics.append_duration_seconds.observe(start.elapsed().as_secs_f64());
     Ok(())
   }
 

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -92,19 +92,26 @@ impl MessageLogMetrics {
       crc_failures.clone(),
     );
 
-    Self { recovery_duration_seconds, append_duration_seconds, segments_rolled, segments_evicted, evicted_bytes, crc_failures }
+    Self {
+      recovery_duration_seconds,
+      append_duration_seconds,
+      segments_rolled,
+      segments_evicted,
+      evicted_bytes,
+      crc_failures,
+    }
   }
 
   /// Returns an instance with unregistered handles — useful for tests that do
   /// not care about observing metric values.
   pub fn noop() -> Self {
     Self {
-      recovery_duration_seconds: Histogram::new(
-        prometheus_client::metrics::histogram::exponential_buckets(0.001, 2.0, 16),
-      ),
-      append_duration_seconds: Histogram::new(
-        prometheus_client::metrics::histogram::exponential_buckets(0.0001, 2.0, 16),
-      ),
+      recovery_duration_seconds: Histogram::new(prometheus_client::metrics::histogram::exponential_buckets(
+        0.001, 2.0, 16,
+      )),
+      append_duration_seconds: Histogram::new(prometheus_client::metrics::histogram::exponential_buckets(
+        0.0001, 2.0, 16,
+      )),
       segments_rolled: Counter::default(),
       segments_evicted: Counter::default(),
       evicted_bytes: Counter::default(),
@@ -1099,7 +1106,13 @@ mod tests {
   async fn create_log_with_segment_max(dir: &std::path::Path, segment_max_bytes: u64) -> FileMessageLog {
     let hash = channel_hash(&StringAtom::from("test_channel"));
     let channel_dir = dir.join(hash.as_ref());
-    FileMessageLog::open_with_segment_max(channel_dir, TEST_MAX_PAYLOAD_SIZE, segment_max_bytes, MessageLogMetrics::noop()).await
+    FileMessageLog::open_with_segment_max(
+      channel_dir,
+      TEST_MAX_PAYLOAD_SIZE,
+      segment_max_bytes,
+      MessageLogMetrics::noop(),
+    )
+    .await
   }
 
   /// Helper: append a single message with the given seq, from, and payload.
@@ -1634,7 +1647,8 @@ mod tests {
   #[compio::test]
   async fn test_factory_creates_independent_logs() {
     let tmp = tempfile::tempdir().unwrap();
-    let factory = FileMessageLogFactory::new(tmp.path().to_path_buf(), TEST_MAX_PAYLOAD_SIZE, MessageLogMetrics::noop());
+    let factory =
+      FileMessageLogFactory::new(tmp.path().to_path_buf(), TEST_MAX_PAYLOAD_SIZE, MessageLogMetrics::noop());
 
     let log_a = factory.create(&StringAtom::from("channel_a")).await;
     let log_b = factory.create(&StringAtom::from("channel_b")).await;

--- a/crates/server/src/channel/manager.rs
+++ b/crates/server/src/channel/manager.rs
@@ -73,8 +73,14 @@ struct ChannelManagerMetrics {
   store_saves: Family<ResultLabel, Counter>,
   store_save_duration_seconds: Histogram,
   store_deletes: Family<ResultLabel, Counter>,
+  store_loads: Family<ResultLabel, Counter>,
+  store_load_duration_seconds: Histogram,
   message_log_flushes: Family<ResultLabel, Counter>,
   message_log_flush_duration_seconds: Histogram,
+  message_log_reads: Family<ResultLabel, Counter>,
+  message_log_read_duration_seconds: Histogram,
+  message_log_entries_returned: Histogram,
+  message_log_deletes: Family<ResultLabel, Counter>,
 }
 
 impl std::fmt::Debug for ChannelManagerMetrics {
@@ -105,6 +111,15 @@ impl ChannelManagerMetrics {
     );
     let store_deletes = Family::default();
     registry.register("store_deletes", "Channel store delete operations", store_deletes.clone());
+    let store_loads = Family::default();
+    registry.register("store_loads", "Channel store load operations", store_loads.clone());
+    let store_load_duration_seconds =
+      Histogram::new(prometheus_client::metrics::histogram::exponential_buckets(0.0001, 2.0, 16));
+    registry.register(
+      "store_load_duration_seconds",
+      "Duration of channel store load operations in seconds",
+      store_load_duration_seconds.clone(),
+    );
     let message_log_flushes = Family::default();
     registry.register("message_log_flushes", "Message log flush operations", message_log_flushes.clone());
     let message_log_flush_duration_seconds =
@@ -114,6 +129,24 @@ impl ChannelManagerMetrics {
       "Duration of message log flush operations in seconds",
       message_log_flush_duration_seconds.clone(),
     );
+    let message_log_reads = Family::default();
+    registry.register("message_log_reads", "Message log read operations", message_log_reads.clone());
+    let message_log_read_duration_seconds =
+      Histogram::new(prometheus_client::metrics::histogram::exponential_buckets(0.0001, 2.0, 16));
+    registry.register(
+      "message_log_read_duration_seconds",
+      "Duration of message log read operations in seconds",
+      message_log_read_duration_seconds.clone(),
+    );
+    let message_log_entries_returned =
+      Histogram::new(prometheus_client::metrics::histogram::exponential_buckets(1.0, 2.0, 11));
+    registry.register(
+      "message_log_entries_returned",
+      "Number of entries returned by a message log read",
+      message_log_entries_returned.clone(),
+    );
+    let message_log_deletes = Family::default();
+    registry.register("message_log_deletes", "Message log delete operations", message_log_deletes.clone());
 
     Self {
       channels_active,
@@ -123,8 +156,14 @@ impl ChannelManagerMetrics {
       store_saves,
       store_save_duration_seconds,
       store_deletes,
+      store_loads,
+      store_load_duration_seconds,
       message_log_flushes,
       message_log_flush_duration_seconds,
+      message_log_reads,
+      message_log_read_duration_seconds,
+      message_log_entries_returned,
+      message_log_deletes,
     }
   }
 
@@ -135,6 +174,39 @@ impl ChannelManagerMetrics {
     match result {
       Ok(()) => self.message_log_flushes.get_or_create(&SUCCESS).inc(),
       Err(_) => self.message_log_flushes.get_or_create(&FAILURE).inc(),
+    };
+  }
+
+  /// Records the outcome of a message log read: observes duration, the number of entries
+  /// returned on success, and increments the success/failure counter.
+  fn record_read(&self, start: Instant, result: &anyhow::Result<u32>) {
+    self.message_log_read_duration_seconds.observe(start.elapsed().as_secs_f64());
+    match result {
+      Ok(count) => {
+        self.message_log_entries_returned.observe(*count as f64);
+        self.message_log_reads.get_or_create(&SUCCESS).inc();
+      },
+      Err(_) => {
+        self.message_log_reads.get_or_create(&FAILURE).inc();
+      },
+    };
+  }
+
+  /// Records the outcome of a message log delete.
+  fn record_message_log_delete(&self, result: &anyhow::Result<()>) {
+    match result {
+      Ok(()) => self.message_log_deletes.get_or_create(&SUCCESS).inc(),
+      Err(_) => self.message_log_deletes.get_or_create(&FAILURE).inc(),
+    };
+  }
+
+  /// Records the outcome of a channel store load: observes duration and increments
+  /// the success/failure counter.
+  fn record_load<T>(&self, start: Instant, result: &anyhow::Result<T>) {
+    self.store_load_duration_seconds.observe(start.elapsed().as_secs_f64());
+    match result {
+      Ok(_) => self.store_loads.get_or_create(&SUCCESS).inc(),
+      Err(_) => self.store_loads.get_or_create(&FAILURE).inc(),
     };
   }
 }
@@ -468,7 +540,10 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
 
   async fn restore(&mut self, hashes: Vec<StringAtom>) {
     for hash in &hashes {
-      let persisted = match self.store.load_channel(hash).await {
+      let start = Instant::now();
+      let result = self.store.load_channel(hash).await;
+      self.metrics.record_load(start, &result);
+      let persisted = match result {
         Ok(p) => p,
         Err(e) => {
           warn!(hash = %hash, error = %e, "skipping channel restore: failed to load persisted channel");
@@ -1343,7 +1418,10 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       pool: &self.history_pool,
     };
 
-    let count = channel.message_log.read(from_seq, limit, &mut visitor).await?;
+    let start = Instant::now();
+    let result = channel.message_log.read(from_seq, limit, &mut visitor).await;
+    self.metrics.record_read(start, &result);
+    let count = result?;
 
     transmitter.send_message(Message::HistoryAck(HistoryAckParameters {
       id: correlation_id,
@@ -1396,10 +1474,12 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
   /// Errors are logged but never propagated. Callers must not depend on storage cleanup
   /// succeeding for in-memory consistency.
   async fn delete_persistent_storage(&mut self, handler: &StringAtom) {
-    if let Some(channel) = self.channels.get_mut(handler)
-      && let Err(e) = channel.message_log.delete().await
-    {
-      warn!(channel = %handler, error = %e, "failed to delete persisted message log");
+    if let Some(channel) = self.channels.get_mut(handler) {
+      let result = channel.message_log.delete().await;
+      self.metrics.record_message_log_delete(&result);
+      if let Err(e) = result {
+        warn!(channel = %handler, error = %e, "failed to delete persisted message log");
+      }
     }
     if let Some(hash) = self.channels.get(handler).and_then(|c| c.store_hash.clone()) {
       match self.store.delete_channel(&hash).await {
@@ -1614,12 +1694,21 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelManager<CS, MLF> {
     // Load persisted channel hashes and determine shard assignment.
     // Each hash's channel is loaded to extract the handler for shard routing,
     // then the shard re-loads the full metadata on its own thread during restore.
-    let channel_hashes: Arc<[StringAtom]> =
-      if restore_channels { self.store.load_channel_hashes().await? } else { Arc::from([]) };
+    let channel_hashes: Arc<[StringAtom]> = if restore_channels {
+      let start = Instant::now();
+      let result = self.store.load_channel_hashes().await;
+      self.metrics.record_load(start, &result);
+      result?
+    } else {
+      Arc::from([])
+    };
 
     let mut shard_hashes: Vec<Vec<StringAtom>> = vec![Vec::new(); shard_count];
     for hash in channel_hashes.iter() {
-      match self.store.load_channel(hash).await {
+      let start = Instant::now();
+      let result = self.store.load_channel(hash).await;
+      self.metrics.record_load(start, &result);
+      match result {
         Ok(persisted) => {
           let shard_id = shard_for(&persisted.handler, shard_count);
           shard_hashes[shard_id].push(hash.clone());

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::channel::ChannelManager;
-use crate::channel::file_message_log::FileMessageLogFactory;
+use crate::channel::file_message_log::{FileMessageLogFactory, MessageLogMetrics};
 use crate::channel::file_store::FileChannelStore;
 use crate::notifier::Notifier;
 use crate::router::GlobalRouter;
@@ -116,10 +116,12 @@ async fn run_server(
   let notifier = Notifier::new(global_router.clone(), modulator_service.modulator.clone());
 
   let channel_reg = guard.sub_registry_with_prefix("narwhal");
+  let message_log_metrics = MessageLogMetrics::register(channel_reg);
 
   let data_dir: PathBuf = c2s_config.storage.data_dir.clone().into();
   let channel_store = FileChannelStore::new(data_dir.clone()).await?;
-  let message_log_factory = FileMessageLogFactory::new(data_dir, c2s_config.limits.max_payload_size);
+  let message_log_factory =
+    FileMessageLogFactory::new(data_dir, c2s_config.limits.max_payload_size, message_log_metrics);
 
   let mut channel_mng = ChannelManager::new(
     global_router.clone(),

--- a/crates/server/tests/c2s_channel_persistence.rs
+++ b/crates/server/tests/c2s_channel_persistence.rs
@@ -9,7 +9,7 @@ use narwhal_protocol::{
   ChannelSeqParameters, ErrorParameters, ErrorReason, HistoryParameters, ListChannelsParameters, Message,
 };
 use narwhal_server::channel::NoopMessageLogFactory;
-use narwhal_server::channel::file_message_log::FileMessageLogFactory;
+use narwhal_server::channel::file_message_log::{FileMessageLogFactory, MessageLogMetrics};
 use narwhal_server::channel::file_store::FileChannelStore;
 use narwhal_test_util::{C2sSuite, TestModulator, default_c2s_config, default_s2m_config};
 use narwhal_util::string_atom::StringAtom;
@@ -192,7 +192,7 @@ async fn test_c2s_history_retrieves_persisted_messages() -> anyhow::Result<()> {
 
   let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
   let store = FileChannelStore::new(data_dir.clone()).await?;
-  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
   let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
   suite.setup().await?;
@@ -276,7 +276,7 @@ async fn test_c2s_chan_seq_returns_sequence_range() -> anyhow::Result<()> {
 
   let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
   let store = FileChannelStore::new(data_dir.clone()).await?;
-  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
   let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
   suite.setup().await?;
@@ -326,7 +326,7 @@ async fn test_c2s_history_partial_range() -> anyhow::Result<()> {
 
   let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
   let store = FileChannelStore::new(data_dir.clone()).await?;
-  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
   let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
   suite.setup().await?;
@@ -399,7 +399,7 @@ async fn test_c2s_history_survives_restart() -> anyhow::Result<()> {
   {
     let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
     let store = FileChannelStore::new(data_dir.clone()).await?;
-    let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+    let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
     let mut suite =
       C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
@@ -422,7 +422,7 @@ async fn test_c2s_history_survives_restart() -> anyhow::Result<()> {
   {
     let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
     let store = FileChannelStore::new(data_dir.clone()).await?;
-    let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+    let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
     let mut suite =
       C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
@@ -482,7 +482,7 @@ async fn test_c2s_history_empty_channel() -> anyhow::Result<()> {
 
   let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
   let store = FileChannelStore::new(data_dir.clone()).await?;
-  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
   let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
   suite.setup().await?;
@@ -529,7 +529,7 @@ async fn test_c2s_chan_seq_empty_channel() -> anyhow::Result<()> {
 
   let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
   let store = FileChannelStore::new(data_dir.clone()).await?;
-  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
   let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
   suite.setup().await?;
@@ -571,7 +571,7 @@ async fn test_c2s_chan_seq_after_eviction() -> anyhow::Result<()> {
   let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
   let store = FileChannelStore::new(data_dir.clone()).await?;
   // Use tiny segments (256 bytes) so eviction kicks in with small messages.
-  let mlf = FileMessageLogFactory::with_segment_max(data_dir.clone(), 4096, 256);
+  let mlf = FileMessageLogFactory::with_segment_max(data_dir.clone(), 4096, 256, MessageLogMetrics::noop());
 
   let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
   suite.setup().await?;
@@ -620,7 +620,7 @@ async fn test_c2s_history_after_eviction() -> anyhow::Result<()> {
   let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
   let store = FileChannelStore::new(data_dir.clone()).await?;
   // Use tiny segments (256 bytes) so eviction kicks in with small messages.
-  let mlf = FileMessageLogFactory::with_segment_max(data_dir.clone(), 4096, 256);
+  let mlf = FileMessageLogFactory::with_segment_max(data_dir.clone(), 4096, 256, MessageLogMetrics::noop());
 
   let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
   suite.setup().await?;
@@ -691,7 +691,7 @@ async fn test_c2s_history_cross_user() -> anyhow::Result<()> {
 
   let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
   let store = FileChannelStore::new(data_dir.clone()).await?;
-  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
   let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
   suite.setup().await?;
@@ -784,7 +784,7 @@ async fn test_c2s_history_survives_restart_after_eviction() -> anyhow::Result<()
   {
     let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
     let store = FileChannelStore::new(data_dir.clone()).await?;
-    let mlf = FileMessageLogFactory::with_segment_max(data_dir.clone(), 4096, 256);
+    let mlf = FileMessageLogFactory::with_segment_max(data_dir.clone(), 4096, 256, MessageLogMetrics::noop());
 
     let mut suite =
       C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
@@ -807,7 +807,7 @@ async fn test_c2s_history_survives_restart_after_eviction() -> anyhow::Result<()
   {
     let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
     let store = FileChannelStore::new(data_dir.clone()).await?;
-    let mlf = FileMessageLogFactory::with_segment_max(data_dir.clone(), 4096, 256);
+    let mlf = FileMessageLogFactory::with_segment_max(data_dir.clone(), 4096, 256, MessageLogMetrics::noop());
 
     let mut suite =
       C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
@@ -893,7 +893,7 @@ async fn test_c2s_history_from_seq_beyond_last() -> anyhow::Result<()> {
 
   let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
   let store = FileChannelStore::new(data_dir.clone()).await?;
-  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
   let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
   suite.setup().await?;
@@ -946,7 +946,7 @@ async fn test_c2s_history_independent_channels() -> anyhow::Result<()> {
 
   let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
   let store = FileChannelStore::new(data_dir.clone()).await?;
-  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
   let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
   suite.setup().await?;
@@ -1055,7 +1055,7 @@ async fn test_c2s_history_and_chan_seq_on_non_persistent_channel() -> anyhow::Re
 
   let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
   let store = FileChannelStore::new(data_dir.clone()).await?;
-  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
   let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
   suite.setup().await?;
@@ -1116,7 +1116,7 @@ async fn test_c2s_toggle_persistence_off_then_on() -> anyhow::Result<()> {
 
   let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
   let store = FileChannelStore::new(data_dir.clone()).await?;
-  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+  let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
   let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
   suite.setup().await?;
@@ -1215,7 +1215,7 @@ async fn test_c2s_chan_seq_survives_restart() -> anyhow::Result<()> {
   {
     let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
     let store = FileChannelStore::new(data_dir.clone()).await?;
-    let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+    let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
     let mut suite =
       C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
@@ -1238,7 +1238,7 @@ async fn test_c2s_chan_seq_survives_restart() -> anyhow::Result<()> {
   {
     let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
     let store = FileChannelStore::new(data_dir.clone()).await?;
-    let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096);
+    let mlf = FileMessageLogFactory::new(data_dir.clone(), 4096, MessageLogMetrics::noop());
 
     let mut suite =
       C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;


### PR DESCRIPTION
## Summary

Adds Prometheus metrics covering gaps in channel persistence instrumentation: the HISTORY read path, segment lifecycle, recovery, CRC failures, store loads, and append latency. All handles register under the existing `narwhal` sub-registry.

### `ChannelManager` (new handles in `ChannelManagerMetrics`)
- `message_log_reads{result}` + `message_log_read_duration_seconds` + `message_log_entries_returned` — recorded around `channel.message_log.read()` in `history()`
- `message_log_deletes{result}` — recorded in `delete_persistent_storage()`
- `store_loads{result}` + `store_load_duration_seconds` — recorded around `load_channel_hashes` / `load_channel` in `bootstrap()` and shard `restore()`

### `FileMessageLog` (new `MessageLogMetrics`, threaded through `FileMessageLogFactory`)
- `message_log_recovery_duration_seconds` — wraps `Inner::recover()`
- `message_log_append_duration_seconds` — wraps `append()`
- `message_log_segments_rolled` — incremented in `roll_segment()`
- `message_log_segments_evicted` + `message_log_evicted_bytes` — incremented per evicted segment
- `message_log_crc_failures` — incremented in `EntryReader::read_at` on CRC mismatch

`MessageLogMetrics::noop()` helper is provided for tests that don't observe metrics.