### PR TITLE
fix(server): avoid blocking mmap flush in file message log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Narwhal will be documented in this file.
 
 ## Unreleased
 
+* [BUGFIX]: Avoid blocking shard runtimes on message-log index flush by replacing synchronous `mmap.flush()` with async `.idx` file `sync_all()`. [#249](https://github.com/lonewolf-io/narwhal/pull/249)
+
 ## 0.6.0 (2026-04-20)
 
 * [CHANGE]: Migrate async runtime from monoio to compio (io_uring). [#212](https://github.com/lonewolf-io/narwhal/pull/212)

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -290,6 +290,11 @@ struct Inner {
   /// Open file handle for the active (latest) segment's .log.
   active_log: Option<compio::fs::File>,
 
+  /// Open file handle for the active segment's pre-allocated `.idx` file.
+  /// Kept open so flushes can use async `sync_all()` instead of blocking
+  /// `mmap.flush()` on the shard runtime thread.
+  active_idx_file: Option<compio::fs::File>,
+
   /// Read-write mmap of the active segment's pre-allocated `.idx` file.
   /// Entries are written directly into this mapping, Kafka-style.
   active_idx_mmap: Option<MmapMut>,
@@ -334,6 +339,7 @@ impl FileMessageLog {
       segment_max_bytes,
       segments: Vec::new(),
       active_log: None,
+      active_idx_file: None,
       active_idx_mmap: None,
       active_idx_write_pos: 0,
       bytes_since_index: 0,
@@ -449,6 +455,7 @@ impl Inner {
         // SAFETY: Single-threaded shard actor; no concurrent access. The active index
         // file is only written to through this mmap.
         if let Ok(mmap) = unsafe { MmapMut::map_mut(&idx_file) } {
+          self.active_idx_file = Some(idx_file);
           self.active_idx_mmap = Some(mmap);
           self.active_idx_write_pos = actual_size;
         }
@@ -707,6 +714,7 @@ impl Inner {
     // SAFETY: Single-threaded shard actor; no concurrent access. The active index
     // file is only written to through this mmap.
     self.active_idx_mmap = Some(unsafe { MmapMut::map_mut(&idx_file)? });
+    self.active_idx_file = Some(idx_file);
     self.active_idx_write_pos = 0;
 
     self.segments.push(SegmentInfo { first_seq, last_seq: 0, file_size: 0, idx_mmap: None });
@@ -719,20 +727,22 @@ impl Inner {
     // Close the log file handle.
     self.active_log = None;
 
-    // Flush the active index mmap, drop it, then truncate the file to its
-    // actual size and remap as a read-only Mmap for the sealed segment.
+    // Sync the active index file, drop the writable mapping, truncate the file
+    // to its actual size, then remap as a read-only Mmap for the sealed segment.
     let write_pos = self.active_idx_write_pos;
-    if let Some(mmap) = self.active_idx_mmap.take() {
-      let _ = mmap.flush();
-      drop(mmap);
+    if let Some(ref idx_file) = self.active_idx_file {
+      let _ = idx_file.sync_all().await;
     }
+    self.active_idx_mmap = None;
+
+    if let Some(ref idx_file) = self.active_idx_file {
+      let _ = idx_file.set_len(write_pos as u64).await;
+      let _ = idx_file.sync_all().await;
+    }
+    self.active_idx_file = None;
 
     if let Some(seg) = self.segments.last() {
       let idx_path = self.channel_dir.join(format!("{:020}.{INDEX_EXT}", seg.first_seq));
-      // Truncate the pre-allocated file to the actual written size.
-      if let Ok(f) = compio::fs::OpenOptions::new().write(true).open(&idx_path).await {
-        let _ = f.set_len(write_pos as u64).await;
-      }
       let mmap = Self::mmap_index(&idx_path).await;
       self.segments.last_mut().unwrap().idx_mmap = mmap;
     }
@@ -875,6 +885,7 @@ impl MessageLog for FileMessageLog {
 
     // Close active handles and drop the active index mmap.
     inner.active_log = None;
+    inner.active_idx_file = None;
     inner.active_idx_mmap = None;
     inner.active_idx_write_pos = 0;
 
@@ -907,8 +918,12 @@ impl MessageLog for FileMessageLog {
     if let Some(ref log_file) = inner.active_log {
       log_file.sync_all().await?;
     }
-    if let Some(ref mmap) = inner.active_idx_mmap {
-      mmap.flush()?;
+    if inner.active_idx_mmap.is_some() {
+      let idx_file = inner
+        .active_idx_file
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("active index mmap is present without an active index file handle"))?;
+      idx_file.sync_all().await?;
     }
 
     Ok(())

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -731,13 +731,13 @@ impl Inner {
     // to its actual size, then remap as a read-only Mmap for the sealed segment.
     let write_pos = self.active_idx_write_pos;
     if let Some(ref idx_file) = self.active_idx_file {
-      let _ = idx_file.sync_all().await;
+      idx_file.sync_all().await?;
     }
     self.active_idx_mmap = None;
 
     if let Some(ref idx_file) = self.active_idx_file {
-      let _ = idx_file.set_len(write_pos as u64).await;
-      let _ = idx_file.sync_all().await;
+      idx_file.set_len(write_pos as u64).await?;
+      idx_file.sync_all().await?;
     }
     self.active_idx_file = None;
 

--- a/docs/architecture/MESSAGE_LOG.md
+++ b/docs/architecture/MESSAGE_LOG.md
@@ -196,17 +196,20 @@ For the default 128 MiB segments with 4096-byte index interval:
 
 New index entries are written directly into the mmap at the current write
 position (`active_idx_write_pos`). This avoids `write()` syscalls for index
-updates — the kernel handles page dirtying and writeback. An explicit
-`mmap.flush()` is called during `flush()` and before segment roll.
+updates — the kernel handles page dirtying and writeback. The active `.idx`
+file handle is kept open and durability is enforced with async
+`sync_all().await` on that file (instead of synchronous `mmap.flush()`), so
+flush/roll do not block the shard runtime thread.
 
 **Sealed segments — read-only `Mmap`:**
 
 When a segment is rolled (finalized), the index lifecycle is:
 
-1. Flush the `MmapMut` and drop it.
-2. Truncate the `.idx` file from its pre-allocated size to the actual written
+1. `sync_all()` the active `.idx` file.
+2. Drop the active `MmapMut`.
+3. Truncate the `.idx` file from its pre-allocated size to the actual written
    size (`active_idx_write_pos` bytes).
-3. Re-open and memory-map read-only (`Mmap`) for the now-sealed segment.
+4. Re-open and memory-map read-only (`Mmap`) for the now-sealed segment.
 
 Sealed index mmaps remain mapped for the lifetime of the segment. They are
 unmapped (dropped) before the segment files are deleted during eviction.
@@ -366,9 +369,13 @@ same file through the kernel page cache.
 
 ### Flush
 
-`flush()` calls `log_file.sync_all().await` (async `fsync` via io_uring) on the
-active segment's `.log` file, and `mmap.flush()` (sync) on the active segment's
-`.idx` mmap.
+`flush()` calls async `sync_all().await` on both active files:
+
+- the active segment's `.log` file
+- the active segment's `.idx` file (whose dirty pages come from `MmapMut` writes)
+
+Both syncs run through compio/io_uring and avoid synchronous `mmap.flush()`
+inside async shard code.
 
 **Durability guarantee:** same as Kafka — data survives process crashes (data is
 in the kernel page cache) but not power loss without fsync. The existing flush
@@ -386,12 +393,13 @@ After write completes:
 │   ├─ No  → done
 │   └─ Yes → roll:
 │       1. Close active .log file handle
-│       2. Flush active .idx MmapMut and drop the mapping
-│       3. Truncate .idx from pre-allocated size to actual written size
-│       4. Re-open .idx as read-only Mmap (now a sealed segment)
-│       5. Create new .log file (named after next seq to be written)
-│       6. Pre-allocate new .idx to max capacity and MmapMut it
-│       7. New segment becomes the active segment
+│       2. sync_all() active .idx file
+│       3. Drop active .idx MmapMut
+│       4. Truncate .idx from pre-allocated size to actual written size
+│       5. Re-open .idx as read-only Mmap (now a sealed segment)
+│       6. Create new .log file (named after next seq to be written)
+│       7. Pre-allocate new .idx to max capacity and MmapMut it
+│       8. New segment becomes the active segment
 ```
 
 ## Read Path


### PR DESCRIPTION
## Summary
- keep an open handle to the active `.idx` file in `FileMessageLog`
- replace synchronous `mmap.flush()` calls in async paths with async `sync_all().await` on the active index file
- sync and truncate the active `.idx` during segment roll before remapping it read-only
- update `docs/architecture/MESSAGE_LOG.md` to document the new flush/roll behavior and non-blocking runtime impact

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p narwhal-server file_message_log`

Closes #246
