### PR TITLE
docs(message-log): define max_messages == 0 as no-eviction

### DIFF
--- a/crates/server/src/channel/store.rs
+++ b/crates/server/src/channel/store.rs
@@ -87,7 +87,9 @@ pub trait LogVisitor {
 #[async_trait(?Send)]
 pub trait MessageLog: 'static {
   /// Appends a message to the log, buffering it in memory without flushing to disk.
-  /// When the number of stored messages exceeds `max_messages`, the oldest entries should be evicted.
+  /// If `max_messages` is greater than `0` and the number of stored messages exceeds it,
+  /// the oldest entries should be evicted. A `max_messages` of `0` disables eviction
+  /// entirely (the log grows unbounded).
   /// Call `flush` to persist buffered writes to durable storage.
   async fn append(&self, message: &Message, payload: &PoolBuffer, max_messages: u32) -> anyhow::Result<()>;
 

--- a/docs/architecture/MESSAGE_LOG.md
+++ b/docs/architecture/MESSAGE_LOG.md
@@ -499,6 +499,7 @@ Eviction is **count-based**, driven by `max_persist_messages`.
 ```
 After each append:
 │
+├─ If max_persist_messages == 0 → skip eviction (no retention limit)
 ├─ Compute logical first_seq = last_seq - max_persist_messages + 1
 ├─ For each segment (oldest first):
 │   └─ Is segment's last_seq < logical first_seq?
@@ -523,6 +524,10 @@ pushes the `.log` file past `SEGMENT_MAX_BYTES`. This is most visible when
 or under bursty traffic where a single segment fills before
 `max_persist_messages` worth of newer messages arrive. Operators sizing disk
 should plan accordingly.
+
+A `max_persist_messages` of `0` is interpreted as **no eviction** — the log
+grows unbounded. This is the de facto behavior of `MessageLog::append` when
+called with `max_messages == 0`.
 
 ## Recovery
 


### PR DESCRIPTION
## Summary

- Document `max_messages == 0` as **no eviction** (the log grows unbounded) on the `MessageLog::append` trait rustdoc and in the Eviction section of `docs/architecture/MESSAGE_LOG.md`.
- This matches the de-facto behavior today — `evict_segments` already short-circuits when `max_messages == 0` — but the contract was undocumented and could read as the opposite ("0 = retain nothing") to a fresh caller.

Behavior is unchanged. Closes #248 