### PR TITLE
docs(message-log): document the active-segment-never-evicted invariant

### DIFF
--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -767,6 +767,8 @@ impl Inner {
 
     let retain_from = self.cached_last_seq.saturating_sub(max_messages as u64 - 1);
 
+    // The active (last) segment is never evicted — there must always be a
+    // segment to append into.
     while self.segments.len() > 1 {
       if self.segments[0].last_seq < retain_from {
         // Drop the segment (and its mmap) before deleting the underlying files.

--- a/docs/architecture/MESSAGE_LOG.md
+++ b/docs/architecture/MESSAGE_LOG.md
@@ -504,6 +504,19 @@ retention window. This means actual disk usage may slightly exceed
 `max_persist_messages` worth of data (by up to one segment's worth of extra
 messages), but the trade-off is clean O(1) eviction with no rewriting.
 
+**Active-segment invariant:** the active (last) segment is **never** evicted,
+even if all of its entries fall outside the retention window — there must
+always be a segment to append into. The worst-case on-disk overhead per
+channel is therefore approximately one segment's worth of data: about
+`SEGMENT_MAX_BYTES` (128 MiB) above `max_persist_messages * avg_entry_size`,
+plus the active `.idx` file's pre-allocated capacity (~384 KB by default) and
+up to one extra entry, since segment rollover only fires after an append
+pushes the `.log` file past `SEGMENT_MAX_BYTES`. This is most visible when
+`max_persist_messages` is small relative to `SEGMENT_MAX_BYTES / avg_entry_size`,
+or under bursty traffic where a single segment fills before
+`max_persist_messages` worth of newer messages arrive. Operators sizing disk
+should plan accordingly.
+
 ## Recovery
 
 On startup, the message log restores its state from disk. Recovery is **fully


### PR DESCRIPTION
## Summary

- `evict_segments` stops at `segments.len() > 1`, so the active (last) segment is **never** evicted regardless of retention. The spec only hand-waved this with "may slightly exceed ... by up to one segment's worth" — operators sizing disk based on `max_persist_messages` alone could under-provision.
- Spell out the invariant and the worst-case overhead (`SEGMENT_MAX_BYTES` per channel above `max_persist_messages * avg_entry_size`) in the Eviction section of `docs/architecture/MESSAGE_LOG.md`.
- Add a one-line comment at the eviction loop site referencing the spec.

Behavior is unchanged. Closes #247

