### PR TITLE
fix(server): harden index base_seq fallback + spec entry-0 rule

### DIFF
--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -785,7 +785,10 @@ impl Inner {
   }
 
   fn maybe_write_index_entry(&mut self, seq: u64, entry_offset: u64) {
-    let base_seq = self.segments.last().map_or(1, |s| s.first_seq);
+    // Callers (only `append`) ensure a segment exists before invoking this.
+    // Failing loudly here is preferable to a `1` fallback that would underflow
+    // `(seq - base_seq) as u32` if the invariant ever changed.
+    let base_seq = self.segments.last().expect("maybe_write_index_entry called with no active segment").first_seq;
     let is_first_in_segment = entry_offset == 0;
 
     if is_first_in_segment || self.bytes_since_index >= INDEX_INTERVAL_BYTES {

--- a/docs/architecture/MESSAGE_LOG.md
+++ b/docs/architecture/MESSAGE_LOG.md
@@ -152,6 +152,7 @@ memory-mapped files (`mmap`) for efficient access.
 | Property         | Value              |
 |------------------|--------------------|
 | Interval         | Every **4096 bytes** of log data written |
+| Entry-0 rule     | An index entry is always written at offset 0 of each segment, regardless of the interval |
 | Header           | None (Kafka-style) |
 | CRC              | None (derived data; rebuilt from `.log` if corrupt) |
 
@@ -193,6 +194,12 @@ capacity = (segment_max_bytes / INDEX_INTERVAL_BYTES + 1) * INDEX_ENTRY_SIZE
 
 For the default 128 MiB segments with 4096-byte index interval:
 `(128 * 1024 * 1024 / 4096 + 1) * 12 ≈ 384 KB`.
+
+The `+ 1` term accounts for the entry-0 rule above: every segment writes an
+index entry at offset 0 regardless of the interval, so the upper bound on
+entries is `(segment_max_bytes / INDEX_INTERVAL_BYTES) + 1`. Changing either
+the formula or the entry-0 rule without updating the other can silently
+overflow the pre-allocated capacity.
 
 New index entries are written directly into the mmap at the current write
 position (`active_idx_write_pos`). This avoids `write()` syscalls for index


### PR DESCRIPTION
## Summary

Two related issues in `maybe_write_index_entry`:

1. **`base_seq` fallback foot-gun.** The `map_or(1, |s| s.first_seq)` fallback was dead code today (`append` always creates a segment first), but if that invariant ever changed and `segments` was empty when `seq < 1`, `(seq - base_seq) as u32` would underflow to `u32::MAX` and a bogus index entry would be written. Replace with `expect(...)` so a future refactor that breaks the invariant fails loudly instead of silently corrupting the index.

2. **Undocumented "always index entry 0" rule.** The active-index pre-allocation formula
   `(segment_max_bytes / INDEX_INTERVAL_BYTES + 1) * INDEX_ENTRY_SIZE`
   relies on every segment forcing an index entry at offset 0 regardless of `bytes_since_index`. The spec only described the index as "every 4096 bytes of log data written" — a future change to either the formula or the entry-0 logic could silently overflow the pre-allocated capacity. Document the rule in the Sparse Index Files section and link it from the pre-allocation formula.

Closes #245
