### PR TITLE
fix(server): validate sealed index files at recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Narwhal will be documented in this file.
 
 ## Unreleased
 
+* [BUGFIX]: Validate sealed message-log index files at recovery time and rebuild them when visibly corrupt, preventing silent gaps in `HISTORY` reads. [#255](https://github.com/lonewolf-io/narwhal/pull/255)
 * [BUGFIX]: Don't promote a sealed segment to "active" during message-log recovery when the on-disk active segment validates to zero entries. [#254](https://github.com/lonewolf-io/narwhal/pull/254)
 * [BUGFIX]: Reject oversized `from`/payload in message-log append to prevent silent segment-tail truncation on recovery. [#250](https://github.com/lonewolf-io/narwhal/pull/250)
 * [BUGFIX]: Avoid blocking shard runtimes on message-log index flush by replacing synchronous `mmap.flush()` with async `.idx` file `sync_all()`. [#249](https://github.com/lonewolf-io/narwhal/pull/249)

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -428,14 +428,14 @@ impl Inner {
         self.bytes_since_index =
           Self::compute_bytes_since_last_index(&log_path, &idx_path, valid_size, &mut self.reader).await;
       } else {
-        // Sealed segment: trust it, rebuild index if missing.
+        // Sealed segment: rebuild the index if missing or visibly corrupt.
         let last_seq = Self::scan_last_seq(&log_path, base_seq, &mut self.reader).await;
         if last_seq == 0 {
           let _ = compio::fs::remove_file(&log_path).await;
           let _ = compio::fs::remove_file(&idx_path).await;
           continue;
         }
-        if compio::fs::metadata(&idx_path).await.is_err() {
+        if !Self::looks_like_valid_index(&idx_path, file_size, self.idx_capacity()).await {
           Self::rebuild_index(&log_path, &idx_path, base_seq, &mut self.reader, &mut idx_buf).await;
         }
         let idx_mmap = Self::mmap_index(&idx_path).await;
@@ -477,6 +477,71 @@ impl Inner {
         }
       }
     }
+  }
+
+  /// Sanity-check a sealed segment's `.idx` file before mmapping it.
+  ///
+  /// The format is unprotected by a checksum, so a corrupted or truncated
+  /// `.idx` would be silently mapped and produce bogus offsets at read time
+  /// (worst case: empty reads from a valid `.log`). These cheap structural
+  /// checks catch the obvious cases; if any fails, the caller rebuilds the
+  /// index by scanning the log:
+  /// - file exists and its size fits in `(0, idx_capacity]` (oversized `.idx`
+  ///   files most often indicate corruption, but can also legitimately appear
+  ///   if `segment_max_bytes` or `INDEX_INTERVAL_BYTES` was reduced between
+  ///   runs — rebuilding from the log handles both cases, and bounding the
+  ///   size first also bounds the buffer we load below),
+  /// - the size is a multiple of `INDEX_ENTRY_SIZE`,
+  /// - the first entry is `(relative_seq=0, offset=0)` (entry-0 rule),
+  /// - both `relative_seq` and `offset` are strictly monotonically increasing
+  ///   across consecutive entries,
+  /// - the last entry's `offset` is strictly less than `log_file_size`.
+  ///
+  /// Returns `false` if the file is missing, malformed, or fails any check.
+  async fn looks_like_valid_index(idx_path: &Path, log_file_size: u64, idx_capacity: u64) -> bool {
+    let Ok(metadata) = compio::fs::metadata(idx_path).await else {
+      return false;
+    };
+    let size = metadata.len();
+    if size == 0 || size > idx_capacity || size % INDEX_ENTRY_SIZE as u64 != 0 {
+      return false;
+    }
+
+    // Size is bounded by idx_capacity above, so loading the whole file is
+    // safe and lets us walk all entries without per-entry syscalls.
+    let Ok(data) = compio::fs::read(idx_path).await else {
+      return false;
+    };
+    // Guard against a race or short read between metadata() and read(): bail
+    // before any subsequent slicing is allowed to assume validated bounds.
+    if data.len() as u64 != size {
+      return false;
+    }
+
+    // Entry-0 rule: the first index entry is always written by
+    // maybe_write_index_entry / rebuild_index as (relative_seq=0, offset=0).
+    let first_rel_seq = u32::from_le_bytes(data[0..4].try_into().unwrap());
+    let first_offset = u64::from_le_bytes(data[4..12].try_into().unwrap());
+    if first_rel_seq != 0 || first_offset != 0 {
+      return false;
+    }
+
+    let entry_count = data.len() / INDEX_ENTRY_SIZE;
+    let mut prev_rel_seq = first_rel_seq;
+    let mut prev_offset = first_offset;
+    for i in 1..entry_count {
+      let off = i * INDEX_ENTRY_SIZE;
+      let rel_seq = u32::from_le_bytes(data[off..off + 4].try_into().unwrap());
+      let offset = u64::from_le_bytes(data[off + 4..off + 12].try_into().unwrap());
+      if rel_seq <= prev_rel_seq || offset <= prev_offset {
+        return false;
+      }
+      prev_rel_seq = rel_seq;
+      prev_offset = offset;
+    }
+
+    // After the loop `prev_offset` is the last entry's offset.
+    prev_offset < log_file_size
   }
 
   /// Compute bytes written since the last index entry for the active segment.
@@ -1841,6 +1906,122 @@ mod tests {
       assert_eq!(visitor.entries[0].seq, 50);
       assert_eq!(visitor.entries[0].payload, b"msg_0050");
     }
+  }
+
+  #[compio::test]
+  async fn test_recovery_rebuilds_corrupt_sealed_index() {
+    // Spec ("Recovery / Guarantees") promises index corruption is recoverable
+    // by scanning the log. Without sanity-checking the .idx at load time, a
+    // corrupted-but-present sealed index would be silently mmapped and the
+    // read path would seek past EOF, returning empty results from valid .log
+    // data. Verify that recovery rebuilds an index whose offsets are bogus.
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Session 1: generate several sealed segments by rolling on a small max.
+    {
+      let log = create_log_with_segment_max(tmp.path(), 256).await;
+      for seq in 1..=40 {
+        let payload = format!("msg_{seq:03}");
+        append_message(&log, seq, "alice@localhost", payload.as_bytes(), 10_000).await;
+      }
+      log.flush().await.unwrap();
+    }
+
+    let channel_dir = {
+      let hash = channel_hash(&StringAtom::from("test_channel"));
+      tmp.path().join(hash.as_ref())
+    };
+
+    // Pick a sealed (non-last) .idx and corrupt it so the last offset points
+    // past the corresponding .log file size.
+    let mut log_files: Vec<_> = std::fs::read_dir(&channel_dir)
+      .unwrap()
+      .filter_map(|e| e.ok())
+      .filter(|e| e.path().extension().is_some_and(|ext| ext == "log"))
+      .collect();
+    log_files.sort_by_key(|e| e.file_name());
+    assert!(log_files.len() >= 3, "expected at least 3 segments, got {}", log_files.len());
+
+    let sealed_log_path = log_files[0].path();
+    let sealed_idx_path = sealed_log_path.with_extension("idx");
+    let sealed_log_size = std::fs::metadata(&sealed_log_path).unwrap().len();
+
+    // Overwrite the .idx with a single entry whose offset is past EOF.
+    let bogus_offset = sealed_log_size + 1_000_000;
+    let mut bogus_idx = Vec::with_capacity(INDEX_ENTRY_SIZE);
+    bogus_idx.extend_from_slice(&0u32.to_le_bytes());
+    bogus_idx.extend_from_slice(&bogus_offset.to_le_bytes());
+    std::fs::write(&sealed_idx_path, &bogus_idx).unwrap();
+
+    // Session 2: recovery should detect the bad offset and rebuild the index.
+    let log = create_log(tmp.path()).await;
+
+    assert_eq!(log.first_seq(), 1);
+    assert_eq!(log.last_seq(), 40);
+
+    // Read starting mid-segment (from_seq > segment's first_seq) so that the
+    // read path actually consults the index. Without the rebuild, the bogus
+    // offset lands past EOF and the corrupted segment yields zero entries —
+    // visitor.entries[0].seq would be the next segment's first seq instead
+    // of 2.
+    let mut visitor = CollectingVisitor::new();
+    let count = log.read(2, 10, &mut visitor).await.unwrap();
+    assert!(count >= 10, "expected at least 10 entries, got {count}");
+    assert_eq!(visitor.entries[0].seq, 2, "first segment was skipped (corrupt index not rebuilt)");
+    assert_eq!(visitor.entries[0].payload, b"msg_002");
+  }
+
+  #[compio::test]
+  async fn test_recovery_rebuilds_non_monotonic_sealed_index() {
+    // A non-monotonic .idx is invalid by construction even if every offset
+    // is in-range. Binary search may incidentally tolerate some misorderings,
+    // so we assert that the structural check actually rebuilt the file
+    // (its bytes no longer match the bogus content we wrote).
+    let tmp = tempfile::tempdir().unwrap();
+
+    {
+      let log = create_log_with_segment_max(tmp.path(), 256).await;
+      for seq in 1..=20 {
+        let payload = format!("msg_{seq:03}");
+        append_message(&log, seq, "alice@localhost", payload.as_bytes(), 10_000).await;
+      }
+      log.flush().await.unwrap();
+    }
+
+    let channel_dir = {
+      let hash = channel_hash(&StringAtom::from("test_channel"));
+      tmp.path().join(hash.as_ref())
+    };
+
+    // Pick the first sealed segment.
+    let mut log_files: Vec<_> = std::fs::read_dir(&channel_dir)
+      .unwrap()
+      .filter_map(|e| e.ok())
+      .filter(|e| e.path().extension().is_some_and(|ext| ext == SEGMENT_EXT))
+      .collect();
+    log_files.sort_by_key(|e| e.file_name());
+    assert!(log_files.len() >= 2, "expected at least 2 segments");
+
+    let sealed_log_path = log_files[0].path();
+    let sealed_idx_path = sealed_log_path.with_extension(INDEX_EXT);
+    let sealed_log_size = std::fs::metadata(&sealed_log_path).unwrap().len();
+    assert!(sealed_log_size > 40, "test assumes sealed log > 40 bytes");
+
+    // Three entries, all in-range, but rel_seq goes backwards (0 → 5 → 3)
+    // and so does offset (0 → 40 → 20). Passes every other check.
+    let mut bad_idx = Vec::with_capacity(3 * INDEX_ENTRY_SIZE);
+    bad_idx.extend_from_slice(&0u32.to_le_bytes());
+    bad_idx.extend_from_slice(&0u64.to_le_bytes());
+    bad_idx.extend_from_slice(&5u32.to_le_bytes());
+    bad_idx.extend_from_slice(&40u64.to_le_bytes());
+    bad_idx.extend_from_slice(&3u32.to_le_bytes());
+    bad_idx.extend_from_slice(&20u64.to_le_bytes());
+    std::fs::write(&sealed_idx_path, &bad_idx).unwrap();
+
+    // Session 2: recovery must rebuild this index.
+    let _log = create_log(tmp.path()).await;
+    let after = std::fs::read(&sealed_idx_path).unwrap();
+    assert_ne!(after, bad_idx, "non-monotonic .idx should have been rebuilt");
   }
 
   // ===== Factory =====

--- a/docs/architecture/MESSAGE_LOG.md
+++ b/docs/architecture/MESSAGE_LOG.md
@@ -545,9 +545,24 @@ start of recovery and reused across all segments to avoid per-segment allocation
 2. For each sealed segment (all except the last):
    ├─ Scan .log with EntryReader (CRC validation) to determine last_seq
    │   Segments with zero valid entries are deleted.
-   ├─ .idx exists? → memory-map read-only (Mmap)
-   └─ .idx missing? → rebuild by scanning .log with EntryReader,
-   │                   write index via write_all_at, then mmap read-only
+   ├─ .idx looks valid? → memory-map read-only (Mmap)
+   └─ .idx missing or visibly corrupt? → rebuild by scanning .log with
+   │                   EntryReader, write index via write_all_at, then
+   │                   mmap read-only
+
+   "Visibly corrupt" means any of: file size falls outside `(0, idx_capacity]`,
+   file size is not a multiple of INDEX_ENTRY_SIZE, the first entry is not
+   `(relative_seq=0, offset=0)` (entry-0 rule), `relative_seq` or `offset` is
+   not strictly monotonically increasing across consecutive entries, or the
+   last entry's offset is not strictly less than the .log file size. Subtle
+   corruption (e.g. a wrong middle-entry offset that lies inside the .log
+   while still preserving monotonicity) is not detected by these checks. A
+   bad but in-range offset can cause an indexed read to start at the wrong
+   position, where `EntryReader` rejects the malformed bytes via CRC32 and
+   the segment's read terminates early — valid later entries in that segment
+   are silently skipped for the affected read. CRC32 prevents returning
+   malformed entries, but completeness is not guaranteed; the recovery path
+   is to delete the `.idx` so it gets rebuilt on next startup.
 
 3. For the active (last) segment:
    ├─ Scan forward with EntryReader, validating CRC32 per entry
@@ -571,7 +586,7 @@ start of recovery and reused across all segments to avoid per-segment allocation
 **Guarantees:**
 - A crash mid-append loses at most the in-progress entry (CRC detects the partial write).
 - A crash during segment roll leaves at most an empty segment file, which is cleaned up.
-- Index corruption is always recoverable by scanning the log.
+- Visibly corrupt sealed indexes (per the checks in step 2) are rebuilt from the log on recovery. Subtle index corruption that passes those structural checks is not detected: a bad but in-range offset can cause an indexed read to start at the wrong position, where CRC32 validation prevents returning malformed entries but valid later entries in that segment may be silently skipped for the affected read. Recovering from this state requires deleting the `.idx` so it gets rebuilt on next startup.
 
 ## Integration
 


### PR DESCRIPTION
## Summary

The spec ("Recovery > Guarantees") promised:

> Index corruption is always recoverable by scanning the log.

…but recovery only rebuilt a sealed segment's \`.idx\` when the file was **missing** (\`crates/server/src/channel/file_message_log.rs:430\`). A corrupted-but-present \`.idx\` was silently mmapped. The read path trusts the offsets returned by \`index_lookup_in\` (\`file_message_log.rs:1010-1013\`) without bounds checking, so a bogus offset (past EOF or mid-entry) caused the segment to yield zero entries from valid \`.log\` data — manifesting as silent gaps in \`HISTORY\` results across multi-segment logs.

## Fix

Add a cheap O(1) structural check before mmapping a sealed \`.idx\`:

- file size is a non-zero multiple of \`INDEX_ENTRY_SIZE\`,
- the first entry's \`relative_seq\` is \`0\` (entry-0 rule),
- the last entry's \`offset\` is strictly less than the \`.log\` file size.

If any check fails, rebuild from the log (same path as the missing-\`.idx\` case).

Update the spec to be honest about the validation scope: visibly corrupt indexes are rebuilt; subtle middle-entry corruption is not detected, but correctness is preserved because every read re-validates CRC32 (worst case: lookup degrades to a linear scan from the segment start).
