### PR TITLE
fix(server): tighten last-offset bound + spec the empty-active-segment recovery branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Narwhal will be documented in this file.
 
 ## Unreleased
 
+* [BUGFIX]: Tighten the sealed-index last-offset validation to require room for a full entry header, and document the empty-active-segment branch of recovery. [#262](https://github.com/lonewolf-io/narwhal/pull/262)
 * [BUGFIX]: Read path no longer falls back to the active segment's index when a sealed segment has no mmap; recovery propagates fatal mmap/open errors so the affected channel refuses to come online instead of silently dropping index updates. [#261](https://github.com/lonewolf-io/narwhal/pull/261)
 * [BUGFIX]: Validate sealed message-log index files at recovery time and rebuild them when visibly corrupt, preventing silent gaps in `HISTORY` reads. [#255](https://github.com/lonewolf-io/narwhal/pull/255)
 * [BUGFIX]: Don't promote a sealed segment to "active" during message-log recovery when the on-disk active segment validates to zero entries. [#254](https://github.com/lonewolf-io/narwhal/pull/254)

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -529,7 +529,10 @@ impl Inner {
   /// - the first entry is `(relative_seq=0, offset=0)` (entry-0 rule),
   /// - both `relative_seq` and `offset` are strictly monotonically increasing
   ///   across consecutive entries,
-  /// - the last entry's `offset` is strictly less than `log_file_size`.
+  /// - the last entry's `offset` leaves room for at least one full entry
+  ///   header in the `.log` file (i.e. `offset + ENTRY_HEADER_SIZE <=
+  ///   log_file_size`); otherwise an indexed read at that offset would fail
+  ///   `EntryReader`'s remaining-bytes check anyway.
   ///
   /// Returns `false` if the file is missing, malformed, or fails any check.
   async fn looks_like_valid_index(idx_path: &Path, log_file_size: u64, idx_capacity: u64) -> bool {
@@ -574,8 +577,9 @@ impl Inner {
       prev_offset = offset;
     }
 
-    // After the loop `prev_offset` is the last entry's offset.
-    prev_offset < log_file_size
+    // After the loop `prev_offset` is the last entry's offset. It must point
+    // at a position where a full entry header fits in the .log file.
+    prev_offset.saturating_add(ENTRY_HEADER_SIZE as u64) <= log_file_size
   }
 
   /// Compute bytes written since the last index entry for the active segment.
@@ -2068,6 +2072,61 @@ mod tests {
     let _log = create_log(tmp.path()).await;
     let after = std::fs::read(&sealed_idx_path).unwrap();
     assert_ne!(after, bad_idx, "non-monotonic .idx should have been rebuilt");
+  }
+
+  #[compio::test]
+  async fn test_recovery_rebuilds_sealed_index_when_last_offset_no_room_for_header() {
+    // Regression for the tightened bound `offset + ENTRY_HEADER_SIZE <=
+    // log_file_size`. An offset that is < log_file_size but leaves no room
+    // for a full entry header passes the older `< log_file_size` check, but
+    // EntryReader::read_at would fail at runtime. The new bound rejects the
+    // index; recovery rebuilds it so reads still work.
+    let tmp = tempfile::tempdir().unwrap();
+    {
+      let log = create_log_with_segment_max(tmp.path(), 256).await;
+      for seq in 1..=20 {
+        let payload = format!("msg_{seq:03}");
+        append_message(&log, seq, "alice@localhost", payload.as_bytes(), 10_000).await;
+      }
+      log.flush().await.unwrap();
+    }
+
+    let channel_dir = {
+      let hash = channel_hash(&StringAtom::from("test_channel"));
+      tmp.path().join(hash.as_ref())
+    };
+
+    let mut log_files: Vec<_> = std::fs::read_dir(&channel_dir)
+      .unwrap()
+      .filter_map(|e| e.ok())
+      .filter(|e| e.path().extension().is_some_and(|ext| ext == SEGMENT_EXT))
+      .collect();
+    log_files.sort_by_key(|e| e.file_name());
+    assert!(log_files.len() >= 2);
+    let sealed_log_path = log_files[0].path();
+    let sealed_idx_path = sealed_log_path.with_extension(INDEX_EXT);
+    let sealed_log_size = std::fs::metadata(&sealed_log_path).unwrap().len();
+    assert!(
+      sealed_log_size > ENTRY_HEADER_SIZE as u64,
+      "test assumes the sealed segment holds at least one full entry"
+    );
+
+    // Two valid-looking entries (monotonic, in-range), but the second's
+    // offset is the smallest value that's `< log_size` while still failing
+    // `+ ENTRY_HEADER_SIZE <= log_size`. Derive it from `ENTRY_HEADER_SIZE`
+    // so the test stays correct if the header layout ever changes.
+    let bad_offset = sealed_log_size - ENTRY_HEADER_SIZE as u64 + 1;
+    let mut bad_idx = Vec::with_capacity(2 * INDEX_ENTRY_SIZE);
+    bad_idx.extend_from_slice(&0u32.to_le_bytes());
+    bad_idx.extend_from_slice(&0u64.to_le_bytes());
+    bad_idx.extend_from_slice(&1u32.to_le_bytes());
+    bad_idx.extend_from_slice(&bad_offset.to_le_bytes());
+    std::fs::write(&sealed_idx_path, &bad_idx).unwrap();
+
+    // Recovery must rebuild this index.
+    let _log = create_log(tmp.path()).await;
+    let after = std::fs::read(&sealed_idx_path).unwrap();
+    assert_ne!(after, bad_idx, ".idx whose last offset leaves no room for a header should have been rebuilt");
   }
 
   #[compio::test]

--- a/docs/architecture/MESSAGE_LOG.md
+++ b/docs/architecture/MESSAGE_LOG.md
@@ -554,7 +554,8 @@ start of recovery and reused across all segments to avoid per-segment allocation
    file size is not a multiple of INDEX_ENTRY_SIZE, the first entry is not
    `(relative_seq=0, offset=0)` (entry-0 rule), `relative_seq` or `offset` is
    not strictly monotonically increasing across consecutive entries, or the
-   last entry's offset is not strictly less than the .log file size. Subtle
+   last entry's offset does not leave room for a full entry header in the
+   `.log` file (i.e. `offset + ENTRY_HEADER_SIZE > log_file_size`). Subtle
    corruption (e.g. a wrong middle-entry offset that lies inside the .log
    while still preserving monotonicity) is not detected by these checks. A
    bad but in-range offset can cause an indexed read to start at the wrong
@@ -567,13 +568,18 @@ start of recovery and reused across all segments to avoid per-segment allocation
 3. For the active (last) segment:
    ├─ Scan forward with EntryReader, validating CRC32 per entry
    ├─ Truncate at the first invalid/partial entry (file.set_len().await)
-   ├─ Rebuild .idx from valid entries (reusing index buffer)
-   ├─ Compute bytes_since_index: read the last index entry to find its offset,
-   │   scan forward from there to count bytes written after it, so the index
-   │   interval resumes correctly on the next append
-   ├─ Open .log for writes (positioned I/O at seg.file_size)
-   ├─ Extend .idx to pre-allocated capacity
-   └─ Memory-map read-write (MmapMut), set write_pos to actual index size
+   ├─ If the scan yielded zero valid entries → delete `.log` + `.idx` and
+   │   skip the open-for-append step below. The next `append()` falls
+   │   through `Inner::create_segment` and creates a fresh segment named
+   │   after that entry's seq. Sealed segments are unaffected.
+   ├─ Otherwise:
+   │   ├─ Rebuild .idx from valid entries (reusing index buffer)
+   │   ├─ Compute bytes_since_index: read the last index entry to find its offset,
+   │   │   scan forward from there to count bytes written after it, so the index
+   │   │   interval resumes correctly on the next append
+   │   ├─ Open .log for writes (positioned I/O at seg.file_size)
+   │   ├─ Extend .idx to pre-allocated capacity
+   │   └─ Memory-map read-write (MmapMut), set write_pos to actual index size
 
 4. Empty/zero-byte .log files → delete (compio::fs::remove_file().await)
 


### PR DESCRIPTION
## Summary

Two small audit findings, bundled because both land in the message-log recovery section.

### #258 — Tighten the sealed-index last-offset bound

\`looks_like_valid_index\` checked \`last_offset < log_file_size\`. An offset like \`log_file_size - 5\` passed validation, but \`EntryReader::read_at\` then bailed on its \`remaining < ENTRY_HEADER_SIZE\` check and the segment scan terminated. CRC kept reads safe, but the sanity check could have rejected this case cheaply.

Now: \`offset + ENTRY_HEADER_SIZE <= log_file_size\`. Spec updated to match.

### #259 — Spec the empty-active-segment recovery branch

After PR #254 the active-segment recovery has two outcomes:

1. Recovered with valid entries → rebuild \`.idx\`, open RW.
2. Zero valid entries → delete \`.log\` + \`.idx\`, leave \`active_log = None\`. The next \`append()\` falls through \`Inner::create_segment\` and creates a fresh segment.

The spec described only outcome 1. A future contributor reading it would not know that \`active_log = None\` post-recovery is the normal state when the active segment was empty/all-corrupt. Step 3 of the Recovery flow now spells out both branches.

## Closes

- Closes #258
- Closes #259