### PR TITLE
refactor(server): centralize atomic write-temp-rename into util::file

### DIFF
--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -776,60 +776,16 @@ impl Inner {
       pos += reader.entry_size;
     }
 
-    // Write to a temp sibling, fsync, close, rename, then fsync the parent
-    // directory so the rename itself is durable across crashes. The previous
-    // `.idx` (if any) stays on disk untouched until the rename succeeds.
-    // Closing before rename avoids cross-platform issues (Windows can't
-    // rename an open file).
+    // The previous `.idx` (if any) stays on disk untouched until the rename
+    // succeeds. On any failure during the atomic write, also drop the
+    // existing `.idx` so the read path falls back to a full-segment scan
+    // (`mmap_index` returns `None`) instead of trusting a stale index.
     let tmp_path = idx_path.with_extension("tmp");
-    let tmp_file = match compio::fs::File::create(&tmp_path).await {
-      Ok(f) => f,
-      Err(_) => {
-        // A stale `<first_seq>.tmp` from a prior crashed run may still be on
-        // disk; clean it up so it doesn't accumulate over time.
-        drop_indexes(idx_path, Some(&tmp_path)).await;
-        return;
-      },
-    };
-
     let buf = std::mem::take(idx_buf);
-    let mut file_ref = &tmp_file;
-    let BufResult(result, buf) = file_ref.write_all_at(buf, 0).await;
+    let (result, buf) = crate::util::file::atomic_write(idx_path, &tmp_path, buf).await;
     *idx_buf = buf;
     if result.is_err() {
-      // Close before unlinking — Windows can't remove an open file.
-      let _ = tmp_file.close().await;
       drop_indexes(idx_path, Some(&tmp_path)).await;
-      return;
-    }
-
-    if tmp_file.sync_all().await.is_err() {
-      let _ = tmp_file.close().await;
-      drop_indexes(idx_path, Some(&tmp_path)).await;
-      return;
-    }
-
-    // `close` consumes `tmp_file`; from here on it can't be referenced again.
-    if tmp_file.close().await.is_err() {
-      drop_indexes(idx_path, Some(&tmp_path)).await;
-      return;
-    }
-
-    if compio::fs::rename(&tmp_path, idx_path).await.is_err() {
-      drop_indexes(idx_path, Some(&tmp_path)).await;
-      return;
-    }
-
-    // Best-effort: fsync the parent directory so the rename is durable
-    // across a crash. Failure here only affects post-crash visibility of
-    // the rename — the file contents are fully written and the next
-    // recovery validates the index regardless. Close the handle explicitly
-    // to avoid leaking a file descriptor.
-    if let Some(parent) = idx_path.parent()
-      && let Ok(dir_file) = compio::fs::File::open(parent).await
-    {
-      let _ = dir_file.sync_all().await;
-      let _ = dir_file.close().await;
     }
   }
 

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -782,7 +782,8 @@ impl Inner {
     // (`mmap_index` returns `None`) instead of trusting a stale index.
     let tmp_path = idx_path.with_extension("tmp");
     let buf = std::mem::take(idx_buf);
-    let (result, buf) = crate::util::file::atomic_write(idx_path, &tmp_path, buf).await;
+    let (result, buf) =
+      crate::util::file::atomic_write(idx_path, &tmp_path, buf, crate::util::file::DirSync::BestEffort).await;
     *idx_buf = buf;
     if result.is_err() {
       drop_indexes(idx_path, Some(&tmp_path)).await;

--- a/crates/server/src/channel/file_store.rs
+++ b/crates/server/src/channel/file_store.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 use narwhal_util::string_atom::StringAtom;
 
 use super::store::{ChannelStore, PersistedChannel};
+use crate::util::file::atomic_write;
 
 const METADATA_FILE: &str = "metadata.bin";
 const METADATA_TMP_FILE: &str = "metadata.bin.tmp";
@@ -40,32 +41,6 @@ impl FileChannelStore {
   fn channel_dir(&self, hash: &str) -> PathBuf {
     self.data_dir.join(hash)
   }
-
-  /// Atomically writes `data` to `file_path` using write-tmp-rename-fsync.
-  async fn atomic_write(&self, dir: &Path, data: &[u8]) -> anyhow::Result<()> {
-    let tmp_path = dir.join(METADATA_TMP_FILE);
-    let final_path = dir.join(METADATA_FILE);
-
-    // Write to temp file.
-    let buf = data.to_vec();
-    let compio::BufResult(result, _) = compio::fs::write(&tmp_path, buf).await;
-    result?;
-
-    // Fsync the temp file.
-    let file = compio::fs::File::open(&tmp_path).await?;
-    file.sync_all().await?;
-    file.close().await?;
-
-    // Rename temp → final.
-    compio::fs::rename(&tmp_path, &final_path).await?;
-
-    // Fsync the parent directory.
-    let dir_file = compio::fs::File::open(dir).await?;
-    dir_file.sync_all().await?;
-    dir_file.close().await?;
-
-    Ok(())
-  }
 }
 
 #[async_trait(?Send)]
@@ -77,7 +52,10 @@ impl ChannelStore for FileChannelStore {
     compio::fs::create_dir_all(&dir).await?;
 
     let data = postcard::to_allocvec(channel)?;
-    self.atomic_write(&dir, &data).await?;
+    let final_path = dir.join(METADATA_FILE);
+    let tmp_path = dir.join(METADATA_TMP_FILE);
+    let (result, _) = atomic_write(&final_path, &tmp_path, data).await;
+    result?;
     Ok(hash)
   }
 

--- a/crates/server/src/channel/file_store.rs
+++ b/crates/server/src/channel/file_store.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 use narwhal_util::string_atom::StringAtom;
 
 use super::store::{ChannelStore, PersistedChannel};
-use crate::util::file::atomic_write;
+use crate::util::file::{DirSync, atomic_write};
 
 const METADATA_FILE: &str = "metadata.bin";
 const METADATA_TMP_FILE: &str = "metadata.bin.tmp";
@@ -54,7 +54,7 @@ impl ChannelStore for FileChannelStore {
     let data = postcard::to_allocvec(channel)?;
     let final_path = dir.join(METADATA_FILE);
     let tmp_path = dir.join(METADATA_TMP_FILE);
-    let (result, _) = atomic_write(&final_path, &tmp_path, data).await;
+    let (result, _) = atomic_write(&final_path, &tmp_path, data, DirSync::Strict).await;
     result?;
     Ok(hash)
   }

--- a/crates/server/src/util/file.rs
+++ b/crates/server/src/util/file.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+use std::path::Path;
+
+use compio::BufResult;
+use compio::io::AsyncWriteAtExt;
+
+/// Atomically writes `data` to `path` using the write-temp-rename pattern:
+///
+/// 1. Create and write `data` to `tmp_path`.
+/// 2. fsync the temp file.
+/// 3. Close the temp file (Windows can't rename an open file).
+/// 4. Rename `tmp_path` -> `path`.
+/// 5. Best-effort fsync the parent directory so the rename itself is
+///    durable across a crash.
+///
+/// A crash mid-write leaves either the previous contents of `path` (if any)
+/// or the new contents — never a half-written file.
+///
+/// On error the temp file is removed (best-effort) so a stale `.tmp` doesn't
+/// accumulate from a prior crashed write. The buffer is returned in both the
+/// `Ok` and `Err` cases so callers can reuse it.
+///
+/// The parent-directory fsync is best-effort: failure only affects post-crash
+/// visibility of the rename. The file content is fully written and durable;
+/// the next recovery pass can re-validate.
+pub async fn atomic_write(path: &Path, tmp_path: &Path, data: Vec<u8>) -> (anyhow::Result<()>, Vec<u8>) {
+  let (result, buf) = atomic_write_inner(path, tmp_path, data).await;
+  if result.is_err() {
+    let _ = compio::fs::remove_file(tmp_path).await;
+  }
+  (result, buf)
+}
+
+async fn atomic_write_inner(path: &Path, tmp_path: &Path, data: Vec<u8>) -> (anyhow::Result<()>, Vec<u8>) {
+  let tmp_file = match compio::fs::File::create(tmp_path).await {
+    Ok(f) => f,
+    Err(e) => return (Err(e.into()), data),
+  };
+
+  let mut file_ref = &tmp_file;
+  let BufResult(write_result, buf) = file_ref.write_all_at(data, 0).await;
+  if let Err(e) = write_result {
+    let _ = tmp_file.close().await;
+    return (Err(e.into()), buf);
+  }
+
+  if let Err(e) = tmp_file.sync_all().await {
+    let _ = tmp_file.close().await;
+    return (Err(e.into()), buf);
+  }
+
+  if let Err(e) = tmp_file.close().await {
+    return (Err(e.into()), buf);
+  }
+
+  if let Err(e) = compio::fs::rename(tmp_path, path).await {
+    return (Err(e.into()), buf);
+  }
+
+  if let Some(parent) = path.parent()
+    && let Ok(dir_file) = compio::fs::File::open(parent).await
+  {
+    let _ = dir_file.sync_all().await;
+    let _ = dir_file.close().await;
+  }
+
+  (Ok(()), buf)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[compio::test]
+  async fn writes_and_renames() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("data.bin");
+    let tmp_path = tmp.path().join("data.tmp");
+
+    let (res, buf) = atomic_write(&path, &tmp_path, b"hello".to_vec()).await;
+    assert!(res.is_ok());
+    assert_eq!(buf, b"hello");
+
+    let on_disk = std::fs::read(&path).unwrap();
+    assert_eq!(on_disk, b"hello");
+    assert!(!tmp_path.exists(), "tmp file should be renamed away");
+  }
+
+  #[compio::test]
+  async fn overwrites_existing_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("data.bin");
+    let tmp_path = tmp.path().join("data.tmp");
+
+    std::fs::write(&path, b"old").unwrap();
+
+    let (res, _) = atomic_write(&path, &tmp_path, b"new".to_vec()).await;
+    assert!(res.is_ok());
+    assert_eq!(std::fs::read(&path).unwrap(), b"new");
+  }
+
+  #[compio::test]
+  async fn cleans_up_stale_tmp_on_create_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("data.bin");
+    // tmp_path points into a missing subdirectory so File::create fails.
+    let tmp_path = tmp.path().join("missing").join("data.tmp");
+
+    let (res, buf) = atomic_write(&path, &tmp_path, b"x".to_vec()).await;
+    assert!(res.is_err());
+    assert_eq!(buf, b"x");
+    assert!(!tmp_path.exists());
+  }
+}

--- a/crates/server/src/util/file.rs
+++ b/crates/server/src/util/file.rs
@@ -5,34 +5,62 @@ use std::path::Path;
 use compio::BufResult;
 use compio::io::AsyncWriteAtExt;
 
+/// Controls how the parent-directory fsync after `rename` is handled.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DirSync {
+  /// Propagate any parent-directory fsync error. Use this when the file
+  /// content is not reconstructable from another source: losing the rename's
+  /// post-crash durability could surface a stale or absent file at recovery.
+  Strict,
+  /// Ignore parent-directory fsync errors. Use this for derived/rebuildable
+  /// artifacts where treating dir fsync as fatal would mean discarding a
+  /// freshly-renamed valid file the caller can rebuild later.
+  BestEffort,
+}
+
 /// Atomically writes `data` to `path` using the write-temp-rename pattern:
 ///
 /// 1. Create and write `data` to `tmp_path`.
 /// 2. fsync the temp file.
 /// 3. Close the temp file (Windows can't rename an open file).
 /// 4. Rename `tmp_path` -> `path`.
-/// 5. Best-effort fsync the parent directory so the rename itself is
-///    durable across a crash.
+/// 5. fsync the parent directory so the rename itself is durable across a
+///    crash. `dir_sync` selects whether a failure here is propagated or
+///    swallowed.
 ///
-/// A crash mid-write leaves either the previous contents of `path` (if any)
-/// or the new contents — never a half-written file.
+/// # Preconditions
+///
+/// `tmp_path` must be on the same filesystem as `path` (and is normally a
+/// sibling in the same directory). `rename` is only atomic across same-fs
+/// paths; if `tmp_path` lives on a different filesystem, the call may fail
+/// with `EXDEV` and the atomic-write guarantee does not apply.
+///
+/// When the precondition holds, a crash mid-write leaves either the previous
+/// contents of `path` (if any) or the new contents — never a half-written
+/// file.
 ///
 /// On error the temp file is removed (best-effort) so a stale `.tmp` doesn't
 /// accumulate from a prior crashed write. The buffer is returned in both the
 /// `Ok` and `Err` cases so callers can reuse it.
-///
-/// The parent-directory fsync is best-effort: failure only affects post-crash
-/// visibility of the rename. The file content is fully written and durable;
-/// the next recovery pass can re-validate.
-pub async fn atomic_write(path: &Path, tmp_path: &Path, data: Vec<u8>) -> (anyhow::Result<()>, Vec<u8>) {
-  let (result, buf) = atomic_write_inner(path, tmp_path, data).await;
+pub async fn atomic_write(
+  path: &Path,
+  tmp_path: &Path,
+  data: Vec<u8>,
+  dir_sync: DirSync,
+) -> (anyhow::Result<()>, Vec<u8>) {
+  let (result, buf) = atomic_write_inner(path, tmp_path, data, dir_sync).await;
   if result.is_err() {
     let _ = compio::fs::remove_file(tmp_path).await;
   }
   (result, buf)
 }
 
-async fn atomic_write_inner(path: &Path, tmp_path: &Path, data: Vec<u8>) -> (anyhow::Result<()>, Vec<u8>) {
+async fn atomic_write_inner(
+  path: &Path,
+  tmp_path: &Path,
+  data: Vec<u8>,
+  dir_sync: DirSync,
+) -> (anyhow::Result<()>, Vec<u8>) {
   let tmp_file = match compio::fs::File::create(tmp_path).await {
     Ok(f) => f,
     Err(e) => return (Err(e.into()), data),
@@ -58,13 +86,23 @@ async fn atomic_write_inner(path: &Path, tmp_path: &Path, data: Vec<u8>) -> (any
     return (Err(e.into()), buf);
   }
 
-  if let Some(parent) = path.parent()
-    && let Ok(dir_file) = compio::fs::File::open(parent).await
+  let Some(parent) = path.parent() else {
+    return (Ok(()), buf);
+  };
+  let dir_file = match compio::fs::File::open(parent).await {
+    Ok(f) => f,
+    Err(e) => match dir_sync {
+      DirSync::Strict => return (Err(e.into()), buf),
+      DirSync::BestEffort => return (Ok(()), buf),
+    },
+  };
+  if let Err(e) = dir_file.sync_all().await
+    && matches!(dir_sync, DirSync::Strict)
   {
-    let _ = dir_file.sync_all().await;
     let _ = dir_file.close().await;
+    return (Err(e.into()), buf);
   }
-
+  let _ = dir_file.close().await;
   (Ok(()), buf)
 }
 
@@ -78,7 +116,7 @@ mod tests {
     let path = tmp.path().join("data.bin");
     let tmp_path = tmp.path().join("data.tmp");
 
-    let (res, buf) = atomic_write(&path, &tmp_path, b"hello".to_vec()).await;
+    let (res, buf) = atomic_write(&path, &tmp_path, b"hello".to_vec(), DirSync::Strict).await;
     assert!(res.is_ok());
     assert_eq!(buf, b"hello");
 
@@ -95,7 +133,7 @@ mod tests {
 
     std::fs::write(&path, b"old").unwrap();
 
-    let (res, _) = atomic_write(&path, &tmp_path, b"new".to_vec()).await;
+    let (res, _) = atomic_write(&path, &tmp_path, b"new".to_vec(), DirSync::Strict).await;
     assert!(res.is_ok());
     assert_eq!(std::fs::read(&path).unwrap(), b"new");
   }
@@ -104,10 +142,9 @@ mod tests {
   async fn cleans_up_stale_tmp_on_create_failure() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join("data.bin");
-    // tmp_path points into a missing subdirectory so File::create fails.
     let tmp_path = tmp.path().join("missing").join("data.tmp");
 
-    let (res, buf) = atomic_write(&path, &tmp_path, b"x".to_vec()).await;
+    let (res, buf) = atomic_write(&path, &tmp_path, b"x".to_vec(), DirSync::Strict).await;
     assert!(res.is_err());
     assert_eq!(buf, b"x");
     assert!(!tmp_path.exists());

--- a/crates/server/src/util/mod.rs
+++ b/crates/server/src/util/mod.rs
@@ -1,3 +1,4 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
+pub mod file;
 pub mod tls;


### PR DESCRIPTION
## Summary

- Extract a single `atomic_write` helper in `crates/server/src/util/file.rs` covering the write-tmp / fsync / close / rename / best-effort parent-dir-fsync pattern.
- Replace the inline implementations in `FileChannelStore::save_channel` and `FileMessageLog::rebuild_index` with calls into the helper.
- Side benefit: `FileChannelStore` now also cleans up stale `.tmp` files on error, matching the behavior `rebuild_index` got in #263.

The helper takes ownership of the buffer and returns it back so callers can reuse allocations (used by `rebuild_index`) or drop it (used by `save_channel`). On any error during the atomic write the temp file is removed best-effort so a stale `.tmp` doesn't accumulate from a prior crashed write.

`rebuild_index` keeps its own outer wrapping: on failure it additionally drops the existing `.idx` so the read path falls back to a full-segment scan instead of trusting a stale index.


