### PR TITLE
fix(server): make bytes_since_index recovery match runtime invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Narwhal will be documented in this file.
 
 ## Unreleased
 
+* [BUGFIX]: Make `bytes_since_index` recovery match the runtime invariant (`file_size - last_index_offset`), eliminating an off-by-one drift that delayed the next index entry by up to one entry's worth of bytes after every restart. [#267](https://github.com/lonewolf-io/narwhal/pull/267)
 * [BUGFIX]: Make sealed-index rebuild atomic via write-temp-rename so a mid-rebuild crash never leaves a partial `.idx` on disk. [#263](https://github.com/lonewolf-io/narwhal/pull/263)
 * [BUGFIX]: Tighten the sealed-index last-offset validation to require room for a full entry header, and document the empty-active-segment branch of recovery. [#262](https://github.com/lonewolf-io/narwhal/pull/262)
 * [BUGFIX]: Read path no longer falls back to the active segment's index when a sealed segment has no mmap; recovery propagates fatal mmap/open errors so the affected channel refuses to come online instead of silently dropping index updates. [#261](https://github.com/lonewolf-io/narwhal/pull/261)

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -368,6 +368,11 @@ impl FileMessageLog {
     result?;
     Ok(FileMessageLog { inner: RefCell::new(inner) })
   }
+
+  #[cfg(test)]
+  fn bytes_since_index(&self) -> u64 {
+    self.inner.borrow().bytes_since_index
+  }
 }
 
 // === impl Inner ===
@@ -433,8 +438,7 @@ impl Inner {
         }
 
         // Determine bytes_since_index for resuming appends.
-        self.bytes_since_index =
-          Self::compute_bytes_since_last_index(&log_path, &idx_path, valid_size, &mut self.reader).await;
+        self.bytes_since_index = Self::compute_bytes_since_last_index(&idx_path, valid_size).await;
       } else {
         // Sealed segment: rebuild the index if missing or visibly corrupt.
         let last_seq = Self::scan_last_seq(&log_path, base_seq, &mut self.reader).await;
@@ -582,49 +586,45 @@ impl Inner {
     prev_offset.saturating_add(ENTRY_HEADER_SIZE as u64) <= log_file_size
   }
 
-  /// Compute bytes written since the last index entry for the active segment.
-  async fn compute_bytes_since_last_index(
-    log_path: &Path,
-    idx_path: &Path,
-    valid_size: u64,
-    reader: &mut EntryReader,
-  ) -> u64 {
+  /// Compute bytes written since the last index entry for the active segment,
+  /// to seed `bytes_since_index` on recovery.
+  ///
+  /// The runtime invariant after each `append` is
+  /// `bytes_since_index = file_size - last_index_offset`: when an index entry
+  /// is written, `bytes_since_index` is reset to 0 and the just-appended
+  /// entry's length is then added back; subsequent non-indexing appends keep
+  /// adding their lengths. So the value at any moment is the total bytes
+  /// from the last index entry (inclusive of the entry it points at) up to
+  /// the end of the log.
+  ///
+  /// We mirror that invariant directly by subtracting the offset of the last
+  /// index entry from `valid_size`, instead of scanning the log forward —
+  /// which is both faster and avoids an off-by-one bug the scan-based
+  /// version had (it skipped the indexed entry's own length, leaving the
+  /// next index entry delayed by up to one entry's worth of bytes after
+  /// every restart).
+  async fn compute_bytes_since_last_index(idx_path: &Path, valid_size: u64) -> u64 {
     if valid_size == 0 {
       return 0;
     }
-    // Read the last index entry to find the offset it covers.
-    if let Ok(idx_data) = compio::fs::read(idx_path).await {
-      let entry_count = idx_data.len() / INDEX_ENTRY_SIZE;
-      if entry_count > 0 {
-        let last_entry_offset = (entry_count - 1) * INDEX_ENTRY_SIZE + 4; // skip relative_seq
-        if last_entry_offset + 8 <= idx_data.len() {
-          let offset = u64::from_le_bytes(idx_data[last_entry_offset..last_entry_offset + 8].try_into().unwrap());
-          // Scan from that offset to compute bytes written after it.
-          if let Ok(file) = compio::fs::File::open(log_path).await {
-            let mut bytes_after = 0u64;
-            let mut pos = offset;
-            let mut first_entry = true;
-            while pos < valid_size {
-              let remaining = valid_size - pos;
-              if !reader.read_at(&file, pos, remaining).await {
-                break;
-              }
-              if first_entry {
-                // The indexed entry itself — skip it but count bytes after.
-                first_entry = false;
-                pos += reader.entry_size;
-                continue;
-              }
-              bytes_after += reader.entry_size;
-              pos += reader.entry_size;
-            }
-            return bytes_after;
-          }
-        }
-      }
+    let Ok(idx_data) = compio::fs::read(idx_path).await else {
+      // Index missing or unreadable — treat the whole valid range as
+      // un-indexed so the next append re-establishes an entry-0.
+      return valid_size;
+    };
+    let entry_count = idx_data.len() / INDEX_ENTRY_SIZE;
+    if entry_count == 0 {
+      return valid_size;
     }
-    // No index entries — all bytes count.
-    valid_size
+    let off_pos = (entry_count - 1) * INDEX_ENTRY_SIZE + 4; // skip relative_seq
+    if off_pos + 8 > idx_data.len() {
+      return valid_size;
+    }
+    let last_index_offset = u64::from_le_bytes(idx_data[off_pos..off_pos + 8].try_into().unwrap());
+    // A pathological index pointing past the validated log tail shouldn't
+    // happen after a fresh `rebuild_index` on the same `valid_size`, but
+    // saturate defensively rather than underflow.
+    valid_size.saturating_sub(last_index_offset)
   }
 
   /// Maximum pre-allocated size for an index file, in bytes.
@@ -1801,6 +1801,45 @@ mod tests {
       assert_eq!(visitor.entries[9].seq, 10);
       assert_eq!(visitor.entries[0].payload, b"persistent");
     }
+  }
+
+  #[compio::test]
+  async fn test_recovery_preserves_bytes_since_index_invariant() {
+    // Regression test: `bytes_since_index` after recovery must equal the
+    // value the runtime had pre-shutdown. Specifically, the runtime
+    // invariant is `file_size - last_index_offset` (the indexed entry's
+    // own length is included in the count). An earlier scan-based
+    // implementation skipped the indexed entry's length, leaving the next
+    // index entry delayed by up to one entry's worth of bytes after every
+    // restart.
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Append a handful of varied-size entries. None of them is large
+    // enough to trigger a second index entry on its own, so the active
+    // segment ends with a single index entry at offset 0 and
+    // `bytes_since_index` equal to the full validated log size.
+    let runtime_value = {
+      let log = create_log(tmp.path()).await;
+      append_message(&log, 1, "alice@localhost", &[0u8; 1000], 0).await;
+      append_message(&log, 2, "alice@localhost", &[0u8; 1500], 0).await;
+      append_message(&log, 3, "alice@localhost", &[0u8; 800], 0).await;
+      log.flush().await.unwrap();
+      log.bytes_since_index()
+    };
+
+    // With a single index entry at offset 0, the runtime invariant is
+    // exactly the validated log size.
+    assert!(runtime_value > 0, "runtime bytes_since_index should be non-zero after appends");
+
+    let recovered = {
+      let log = create_log(tmp.path()).await;
+      log.bytes_since_index()
+    };
+
+    assert_eq!(
+      recovered, runtime_value,
+      "recovered bytes_since_index ({recovered}) must match the runtime invariant ({runtime_value})"
+    );
   }
 
   #[compio::test]

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -608,8 +608,12 @@ impl Inner {
       return 0;
     }
     let Ok(idx_data) = compio::fs::read(idx_path).await else {
-      // Index missing or unreadable — treat the whole valid range as
-      // un-indexed so the next append re-establishes an entry-0.
+      // Index missing or unreadable — conservatively treat the whole valid
+      // range as un-indexed. This seeds `bytes_since_index` from the full
+      // validated log size; the normal append/index-interval logic decides
+      // when the next index entry is written. In a successful recovery
+      // the active `.idx` is rebuilt earlier on this same path, so this
+      // branch is primarily a fallback for prior open/read failures.
       return valid_size;
     };
     let entry_count = idx_data.len() / INDEX_ENTRY_SIZE;
@@ -1814,10 +1818,10 @@ mod tests {
     // restart.
     let tmp = tempfile::tempdir().unwrap();
 
-    // Append a handful of varied-size entries. None of them is large
-    // enough to trigger a second index entry on its own, so the active
-    // segment ends with a single index entry at offset 0 and
-    // `bytes_since_index` equal to the full validated log size.
+    // Append a handful of varied-size entries. Their total appended bytes
+    // remain below `INDEX_INTERVAL_BYTES`, so the active segment still has
+    // only the initial index entry at offset 0 and `bytes_since_index`
+    // equals the full validated log size.
     let runtime_value = {
       let log = create_log(tmp.path()).await;
       append_message(&log, 1, "alice@localhost", &[0u8; 1000], 0).await;

--- a/docs/architecture/MESSAGE_LOG.md
+++ b/docs/architecture/MESSAGE_LOG.md
@@ -646,9 +646,12 @@ start of recovery and reused across all segments to avoid per-segment allocation
    │   named after that entry's seq. Sealed segments are unaffected.
    ├─ Otherwise:
    │   ├─ Rebuild .idx from valid entries (reusing index buffer)
-   │   ├─ Compute bytes_since_index: read the last index entry to find its offset,
-   │   │   scan forward from there to count bytes written after it, so the index
-   │   │   interval resumes correctly on the next append
+   │   ├─ Compute bytes_since_index = `valid_size - last_index_offset` (read
+   │   │   the last entry from the freshly rebuilt `.idx`). The runtime
+   │   │   invariant after each append is that `bytes_since_index` equals
+   │   │   the byte distance from the last index entry to the end of the
+   │   │   log (inclusive of the indexed entry's own length); mirroring it
+   │   │   directly avoids an off-by-one drift across restarts
 
 4. Open the active segment for appending **only if** step 3 actually recovered
    a non-empty active segment (`active_segment_recovered = true`). When step 3


### PR DESCRIPTION
## Summary

The runtime invariant after each `append` is that `bytes_since_index == file_size - last_index_offset`: when an index entry is written, `bytes_since_index` is reset to 0, then the just-appended entry's length is added back; subsequent non-indexing appends keep adding their lengths. So the value at any point is the byte distance from the last index entry (inclusive of the entry it points at) to the end of the log.

`compute_bytes_since_last_index` was computing this by re-scanning the log from the last index offset — but the scan explicitly skipped the indexed entry's own length, so the recovered value was always short by exactly that amount. Effect: after every restart, the next index entry was delayed by up to one entry's worth of bytes, producing slightly non-uniform index spacing around restart points. CRC validation kept reads correct; the only externally visible artifact was a tiny extra scan distance.

### Fix

Replace the scan with a direct subtraction against the freshly rebuilt `.idx`'s last entry. Drops the unused `log_path` / `reader` parameters and the helper's whole inner loop.

### Regression test

`test_recovery_preserves_bytes_since_index_invariant` appends a few varied-size entries, captures the runtime `bytes_since_index`, then opens a fresh `FileMessageLog` against the same directory and asserts the recovered value equals the runtime value. Added a `#[cfg(test)] fn bytes_since_index(&self) -> u64` accessor to enable the assertion.

### Spec update

`docs/architecture/MESSAGE_LOG.md` updated to describe the simpler approach and call out the invariant explicitly.

## Test plan

- [x] `cargo test -p narwhal-server --lib channel::file_message_log` — all 33 tests pass, including the new regression.
- [ ] Confirm the simplified function still returns correct values when the `.idx` is missing or empty (the early returns cover both — falls back to `valid_size`).