### PR TITLE
fix(server): reject seq=0 and non-monotonic seq in append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Narwhal will be documented in this file.
 
 ## Unreleased
 
+* [BUGFIX]: Reject `seq=0` and non-monotonic `seq` in `FileMessageLog::append` to prevent caller-contract violations from silently corrupting the log's sentinel-based seq tracking and the sparse index's monotonicity invariant. [#268](https://github.com/lonewolf-io/narwhal/pull/268)
 * [BUGFIX]: Make sealed-index rebuild atomic via write-temp-rename so a mid-rebuild crash never leaves a partial `.idx` on disk. [#263](https://github.com/lonewolf-io/narwhal/pull/263)
 * [BUGFIX]: Tighten the sealed-index last-offset validation to require room for a full entry header, and document the empty-active-segment branch of recovery. [#262](https://github.com/lonewolf-io/narwhal/pull/262)
 * [BUGFIX]: Read path no longer falls back to the active segment's index when a sealed segment has no mmap; recovery propagates fatal mmap/open errors so the affected channel refuses to come online instead of silently dropping index updates. [#261](https://github.com/lonewolf-io/narwhal/pull/261)

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -978,6 +978,28 @@ impl MessageLog for FileMessageLog {
     let from = params.from.as_ref().as_bytes();
     let payload_bytes = payload.as_slice();
 
+    // Reject `seq == 0` and non-strictly-monotonic sequences before any state
+    // change. `0` is the empty-log sentinel returned by `first_seq`/`last_seq`,
+    // so writing an entry with `seq == 0` would persist data while leaving
+    // both cached values at 0 — the log would appear empty afterwards. A
+    // `seq <= cached_last_seq` would corrupt the sparse index, whose binary
+    // search assumes strictly monotonic `relative_seq` per segment; a
+    // subsequent recovery would mark the index as visibly corrupt and rebuild
+    // it from the same broken log on every startup.
+    //
+    // These are caller-contract violations rather than expected runtime
+    // states, so we surface them loudly instead of silently corrupting on
+    // disk.
+    if seq == 0 {
+      anyhow::bail!("seq must be > 0 (0 is reserved as the empty-log sentinel)");
+    }
+    if seq <= inner.cached_last_seq {
+      anyhow::bail!(
+        "seq must be strictly greater than last_seq: got {seq}, last_seq is {}",
+        inner.cached_last_seq
+      );
+    }
+
     // Reject oversized entries before any state change. The read-side
     // `EntryReader::body` buffer is sized for `NID_MAX_LENGTH + max_payload_size
     // + CRC_SIZE`; anything larger would be unreadable on recovery and the
@@ -1661,6 +1683,50 @@ mod tests {
     assert_eq!(log.last_seq(), 0);
     append_message(&log, 1, "alice@localhost", b"data", 100).await;
     assert_eq!(log.last_seq(), 1);
+  }
+
+  #[compio::test]
+  async fn test_append_rejects_zero_seq() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = create_log(tmp.path()).await;
+
+    let msg = make_message("alice@localhost", "!test@localhost", 0, 1000, 4);
+    let pool_buf = make_payload(b"data").await;
+    let err = log.append(&msg, &pool_buf, 100).await.unwrap_err();
+    assert!(err.to_string().contains("seq must be > 0"), "unexpected error: {err}");
+
+    // Log state is unchanged: still empty, so a fresh append at seq=1 works.
+    assert_eq!(log.first_seq(), 0);
+    assert_eq!(log.last_seq(), 0);
+    append_message(&log, 1, "alice@localhost", b"data", 100).await;
+    assert_eq!(log.last_seq(), 1);
+  }
+
+  #[compio::test]
+  async fn test_append_rejects_non_monotonic_seq() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = create_log(tmp.path()).await;
+
+    append_message(&log, 5, "alice@localhost", b"first", 100).await;
+
+    // Same seq.
+    let dup = make_message("alice@localhost", "!test@localhost", 5, 1000, 4);
+    let buf = make_payload(b"dup!").await;
+    let err = log.append(&dup, &buf, 100).await.unwrap_err();
+    assert!(err.to_string().contains("strictly greater than last_seq"), "unexpected error: {err}");
+
+    // Lower seq.
+    let lower = make_message("alice@localhost", "!test@localhost", 3, 1000, 4);
+    let buf = make_payload(b"low!").await;
+    let err = log.append(&lower, &buf, 100).await.unwrap_err();
+    assert!(err.to_string().contains("strictly greater than last_seq"), "unexpected error: {err}");
+
+    // last_seq unchanged.
+    assert_eq!(log.last_seq(), 5);
+
+    // Higher seq still works.
+    append_message(&log, 6, "alice@localhost", b"next", 100).await;
+    assert_eq!(log.last_seq(), 6);
   }
 
   #[compio::test]

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -994,10 +994,7 @@ impl MessageLog for FileMessageLog {
       anyhow::bail!("seq must be > 0 (0 is reserved as the empty-log sentinel)");
     }
     if seq <= inner.cached_last_seq {
-      anyhow::bail!(
-        "seq must be strictly greater than last_seq: got {seq}, last_seq is {}",
-        inner.cached_last_seq
-      );
+      anyhow::bail!("seq must be strictly greater than last_seq: got {seq}, last_seq is {}", inner.cached_last_seq);
     }
 
     // Reject oversized entries before any state change. The read-side

--- a/docs/architecture/MESSAGE_LOG.md
+++ b/docs/architecture/MESSAGE_LOG.md
@@ -268,6 +268,13 @@ zero-filled pre-allocated tail.
 pub trait MessageLog: 'static {
     /// Append a message and its payload to the log.
     /// When message count exceeds `max_messages`, oldest segments are evicted.
+    ///
+    /// **Caller-contract validation:** `append` rejects (with `Err`) any
+    /// message whose `seq` is `0` (the empty-log sentinel) or `<= last_seq()`
+    /// (non-strictly-monotonic). These cases would silently corrupt the
+    /// log's in-memory `first_seq`/`last_seq` tracking and the sparse
+    /// index's monotonicity invariant respectively, so they are surfaced
+    /// loudly rather than persisted.
     async fn append(
         &self,
         message: &Message,


### PR DESCRIPTION
## Summary

`FileMessageLog::append` accepted any `seq` the caller passed without validating the two invariants the rest of the log depends on. Both cases are caller-contract violations rather than expected runtime states, but the on-disk consequences are catastrophic, so it's worth a defensive guard at the boundary.

### `seq != 0`

`0` is the empty-log sentinel returned by `first_seq()`/`last_seq()`. Appending `seq == 0` would persist data to disk while leaving both cached values at 0:

```rust
if inner.cached_first_seq == 0 {
    inner.cached_first_seq = seq;  // still 0
}
inner.cached_last_seq = seq;       // still 0
```

A subsequent restart re-derives `cached_first_seq` / `cached_last_seq` from segment metadata. The active segment's `last_seq` would be 0 too (the appended entry's seq), so the log would silently hide its own contents from `read()`.

### `seq > last_seq()`

The sparse index's binary search (`index_lookup_in`) assumes strictly monotonic `relative_seq` per segment. `looks_like_valid_index` rejects any `.idx` whose entries aren't strictly monotonic. A non-monotonic append would persist into the `.log`, force `.idx` rebuild on every recovery (the rebuild is also non-monotonic, so it fails validation again), and silently produce wrong offsets for indexed reads.

### Fix

Two `anyhow::bail!` checks at the top of `append`, immediately before the existing oversized-`from` / oversized-payload checks. No state has been mutated yet, so the rejection is clean.

### Tests

- `test_append_rejects_zero_seq` — bails with `seq must be > 0`, log state unchanged, subsequent valid `seq=1` append succeeds.
- `test_append_rejects_non_monotonic_seq` — duplicate seq and lower seq both bail with `strictly greater than last_seq`, `last_seq` unchanged, subsequent higher seq succeeds.

## Test plan

- [x] `cargo test -p narwhal-server --lib channel::file_message_log` — 34 tests pass (32 prior + 2 new).
- [x] `cargo test -p narwhal-server` — full crate suite still green; no existing test relies on out-of-contract `seq` values.