### PR TITLE
feat(server): surface mid-segment corruption in sealed segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Narwhal will be documented in this file.
 
 ## Unreleased
 
-* [ENHANCEMENT]: Surface mid-segment CRC failures in sealed message-log segments via a new `message_log_sealed_segment_truncations` counter and a `tracing::warn!`, so disk corruption past the first entry of a sealed segment shows up as telemetry instead of silent missing history. [#269](https://github.com/lonewolf-io/narwhal/pull/269)
+* [ENHANCEMENT]: Surface sealed message-log segments whose recovery validation scan terminates before EOF (CRC mismatch, unreadable header, oversized declared lengths, truncated tail, or I/O error) via a new `message_log_sealed_segment_truncations` counter and a `tracing::warn!`, so silent data loss past the validated region shows up as telemetry instead of being discovered later via missing history. [#269](https://github.com/lonewolf-io/narwhal/pull/269)
 * [BUGFIX]: Reject `seq=0` and non-monotonic `seq` in `FileMessageLog::append` to prevent caller-contract violations from silently corrupting the log's sentinel-based seq tracking and the sparse index's monotonicity invariant. [#268](https://github.com/lonewolf-io/narwhal/pull/268)
 * [BUGFIX]: Make sealed-index rebuild atomic via write-temp-rename so a mid-rebuild crash never leaves a partial `.idx` on disk. [#263](https://github.com/lonewolf-io/narwhal/pull/263)
 * [BUGFIX]: Tighten the sealed-index last-offset validation to require room for a full entry header, and document the empty-active-segment branch of recovery. [#262](https://github.com/lonewolf-io/narwhal/pull/262)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Narwhal will be documented in this file.
 
 ## Unreleased
 
+* [ENHANCEMENT]: Surface mid-segment CRC failures in sealed message-log segments via a new `message_log_sealed_segment_truncations` counter and a `tracing::warn!`, so disk corruption past the first entry of a sealed segment shows up as telemetry instead of silent missing history. [#269](https://github.com/lonewolf-io/narwhal/pull/269)
 * [BUGFIX]: Make sealed-index rebuild atomic via write-temp-rename so a mid-rebuild crash never leaves a partial `.idx` on disk. [#263](https://github.com/lonewolf-io/narwhal/pull/263)
 * [BUGFIX]: Tighten the sealed-index last-offset validation to require room for a full entry header, and document the empty-active-segment branch of recovery. [#262](https://github.com/lonewolf-io/narwhal/pull/262)
 * [BUGFIX]: Read path no longer falls back to the active segment's index when a sealed segment has no mmap; recovery propagates fatal mmap/open errors so the affected channel refuses to come online instead of silently dropping index updates. [#261](https://github.com/lonewolf-io/narwhal/pull/261)

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -458,12 +458,15 @@ impl Inner {
           let _ = compio::fs::remove_file(&idx_path).await;
           continue;
         }
-        // Mid-segment CRC failure on a sealed segment is silent data loss:
-        // the .log keeps the corrupted bytes and any valid entries past
-        // them, but `last_seq` is pinned to the pre-corruption position
+        // The validation scan terminated before EOF on a sealed segment.
+        // This can mean a CRC mismatch, an unreadable header, oversized
+        // declared lengths, a truncated tail, or an I/O error — any of
+        // which is silent data loss: the .log still holds the trailing
+        // bytes, but `last_seq` is pinned to the last validated position
         // and reads stop there. Surface this to operators via a metric +
         // warn log so disk health can be investigated rather than
-        // discovered later via missing history.
+        // discovered later via missing history. The `crc_failures`
+        // counter narrows the root cause to CRC mismatches specifically.
         if valid_size < file_size {
           self.metrics.sealed_segment_truncations.inc();
           tracing::warn!(
@@ -472,7 +475,7 @@ impl Inner {
             valid_size,
             last_valid_seq = last_seq,
             lost_bytes = file_size - valid_size,
-            "sealed message-log segment failed CRC mid-file; entries past the failure are unreachable"
+            "sealed message-log segment validation scan terminated before EOF; entries past the failure are unreachable"
           );
         }
         if !Self::looks_like_valid_index(&idx_path, valid_size, self.idx_capacity()).await {
@@ -481,7 +484,7 @@ impl Inner {
         let idx_mmap = Self::mmap_index(&idx_path).await;
         // Use `valid_size` rather than the on-disk `file_size` so subsequent
         // reads stop at the last validated entry and never attempt to
-        // decode bytes past the CRC failure boundary.
+        // decode bytes past the validation boundary.
         self.segments.push(SegmentInfo { first_seq: base_seq, last_seq, file_size: valid_size, idx_mmap });
       }
     }

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -55,6 +55,13 @@ pub struct MessageLogMetrics {
   segments_evicted: Counter,
   evicted_bytes: Counter,
   crc_failures: Counter,
+  /// Incremented once per sealed segment whose CRC scan terminates before
+  /// the file's actual end during recovery. Indicates bit rot or other
+  /// mid-segment data corruption: the segment's `last_seq` is set to the
+  /// last valid entry, and any valid entries past the corruption boundary
+  /// are silently invisible to subsequent reads. Operators should treat a
+  /// non-zero value as a signal to investigate disk health.
+  sealed_segment_truncations: Counter,
 }
 
 impl std::fmt::Debug for MessageLogMetrics {
@@ -92,6 +99,12 @@ impl MessageLogMetrics {
       "Message log entries rejected due to CRC mismatch",
       crc_failures.clone(),
     );
+    let sealed_segment_truncations = Counter::default();
+    registry.register(
+      "message_log_sealed_segment_truncations",
+      "Sealed segments whose CRC scan terminated before EOF on recovery (likely bit rot or mid-segment corruption)",
+      sealed_segment_truncations.clone(),
+    );
 
     Self {
       recovery_duration_seconds,
@@ -100,6 +113,7 @@ impl MessageLogMetrics {
       segments_evicted,
       evicted_bytes,
       crc_failures,
+      sealed_segment_truncations,
     }
   }
 
@@ -117,6 +131,7 @@ impl MessageLogMetrics {
       segments_evicted: Counter::default(),
       evicted_bytes: Counter::default(),
       crc_failures: Counter::default(),
+      sealed_segment_truncations: Counter::default(),
     }
   }
 }
@@ -436,18 +451,38 @@ impl Inner {
         self.bytes_since_index =
           Self::compute_bytes_since_last_index(&log_path, &idx_path, valid_size, &mut self.reader).await;
       } else {
-        // Sealed segment: rebuild the index if missing or visibly corrupt.
-        let last_seq = Self::scan_last_seq(&log_path, base_seq, &mut self.reader).await;
+        // Sealed segment: validate, rebuild the index if missing or visibly corrupt.
+        let (last_seq, valid_size) = Self::scan_and_validate(&log_path, base_seq, &mut self.reader).await;
         if last_seq == 0 {
           let _ = compio::fs::remove_file(&log_path).await;
           let _ = compio::fs::remove_file(&idx_path).await;
           continue;
         }
-        if !Self::looks_like_valid_index(&idx_path, file_size, self.idx_capacity()).await {
+        // Mid-segment CRC failure on a sealed segment is silent data loss:
+        // the .log keeps the corrupted bytes and any valid entries past
+        // them, but `last_seq` is pinned to the pre-corruption position
+        // and reads stop there. Surface this to operators via a metric +
+        // warn log so disk health can be investigated rather than
+        // discovered later via missing history.
+        if valid_size < file_size {
+          self.metrics.sealed_segment_truncations.inc();
+          tracing::warn!(
+            path = %log_path.display(),
+            file_size,
+            valid_size,
+            last_valid_seq = last_seq,
+            lost_bytes = file_size - valid_size,
+            "sealed message-log segment failed CRC mid-file; entries past the failure are unreachable"
+          );
+        }
+        if !Self::looks_like_valid_index(&idx_path, valid_size, self.idx_capacity()).await {
           Self::rebuild_index(&log_path, &idx_path, base_seq, &mut self.reader, &mut idx_buf).await;
         }
         let idx_mmap = Self::mmap_index(&idx_path).await;
-        self.segments.push(SegmentInfo { first_seq: base_seq, last_seq, file_size, idx_mmap });
+        // Use `valid_size` rather than the on-disk `file_size` so subsequent
+        // reads stop at the last validated entry and never attempt to
+        // decode bytes past the CRC failure boundary.
+        self.segments.push(SegmentInfo { first_seq: base_seq, last_seq, file_size: valid_size, idx_mmap });
       }
     }
 
@@ -701,12 +736,6 @@ impl Inner {
     }
 
     (last_seq, pos)
-  }
-
-  /// Scan a sealed segment to find its last seq (fast path: trust CRC).
-  async fn scan_last_seq(log_path: &Path, base_seq: u64, reader: &mut EntryReader) -> u64 {
-    let (last_seq, _) = Self::scan_and_validate(log_path, base_seq, reader).await;
-    last_seq
   }
 
   /// Rebuild the .idx file by scanning the .log file.
@@ -1300,16 +1329,21 @@ mod tests {
 
   /// Helper: create a FileMessageLog with a custom segment size threshold.
   async fn create_log_with_segment_max(dir: &std::path::Path, segment_max_bytes: u64) -> FileMessageLog {
+    create_log_with_segment_max_and_metrics(dir, segment_max_bytes, MessageLogMetrics::noop()).await
+  }
+
+  /// Helper: create a FileMessageLog with a custom segment size threshold and a
+  /// caller-supplied metrics struct, so tests can observe metric increments.
+  async fn create_log_with_segment_max_and_metrics(
+    dir: &std::path::Path,
+    segment_max_bytes: u64,
+    metrics: MessageLogMetrics,
+  ) -> FileMessageLog {
     let hash = channel_hash(&StringAtom::from("test_channel"));
     let channel_dir = dir.join(hash.as_ref());
-    FileMessageLog::open_with_segment_max(
-      channel_dir,
-      TEST_MAX_PAYLOAD_SIZE,
-      segment_max_bytes,
-      MessageLogMetrics::noop(),
-    )
-    .await
-    .expect("recovery should succeed in tests")
+    FileMessageLog::open_with_segment_max(channel_dir, TEST_MAX_PAYLOAD_SIZE, segment_max_bytes, metrics)
+      .await
+      .expect("recovery should succeed in tests")
   }
 
   /// Helper: append a single message with the given seq, from, and payload.
@@ -1848,6 +1882,86 @@ mod tests {
       assert_eq!(count, 5);
       assert_eq!(visitor.entries[4].seq, 5);
       assert_eq!(visitor.entries[4].payload, b"complete");
+    }
+  }
+
+  #[compio::test]
+  async fn test_recovery_increments_metric_on_sealed_segment_corruption() {
+    // Regression test: a CRC failure mid-way through a sealed segment is
+    // silent data loss — the bytes past the failure are unreachable but the
+    // file stays on disk. Recovery must surface this as both a metric
+    // increment and a tracing warning so disk health can be investigated.
+    //
+    // The test uses a small `segment_max_bytes` to roll into a sealed
+    // segment quickly, corrupts a byte in the middle of that sealed
+    // segment's `.log`, then re-opens with a shared metrics handle and
+    // asserts the truncation counter advanced and `last_seq` stops at the
+    // pre-corruption entry.
+    let tmp = tempfile::tempdir().unwrap();
+    let metrics = MessageLogMetrics::noop();
+
+    let appended = 8u64;
+    {
+      let log = create_log_with_segment_max_and_metrics(tmp.path(), 4096, metrics.clone()).await;
+      for seq in 1..=appended {
+        // ~1054-byte entries → roll fires after ~4 entries so segment 1 ends
+        // up sealed with multiple entries we can corrupt mid-file.
+        append_message(&log, seq, "alice@localhost", &vec![0u8; 1024], 10_000).await;
+      }
+      log.flush().await.unwrap();
+    }
+
+    // Truncation counter is per-recovery; the *first* recovery saw clean
+    // segments, so it must still be zero.
+    assert_eq!(metrics.sealed_segment_truncations.get(), 0);
+
+    let channel_dir = {
+      let hash = channel_hash(&StringAtom::from("test_channel"));
+      tmp.path().join(hash.as_ref())
+    };
+
+    // Find sealed segments (every .log except the newest).
+    let mut log_files: Vec<_> = std::fs::read_dir(&channel_dir)
+      .unwrap()
+      .filter_map(|e| e.ok())
+      .filter(|e| e.path().extension().is_some_and(|ext| ext == "log"))
+      .collect();
+    log_files.sort_by_key(|e| e.file_name());
+    assert!(log_files.len() >= 2, "test setup expected at least one sealed segment + one active");
+
+    // Flip a byte deep inside the first sealed segment so the CRC of an
+    // entry in the middle of the file fails. The file's tail bytes are
+    // still bit-perfect on disk, so recovery's mid-segment scan will stop
+    // before EOF.
+    let sealed_path = log_files[0].path();
+    let sealed_size = std::fs::metadata(&sealed_path).unwrap().len();
+    use std::io::{Seek, SeekFrom, Write};
+    let mut f = std::fs::OpenOptions::new().write(true).read(true).open(&sealed_path).unwrap();
+    f.seek(SeekFrom::Start(sealed_size / 2)).unwrap();
+    f.write_all(&[0xFF]).unwrap();
+    f.sync_all().unwrap();
+
+    {
+      let log = create_log_with_segment_max_and_metrics(tmp.path(), 4096, metrics.clone()).await;
+      // Recovery should have detected the truncation on the sealed segment.
+      assert_eq!(
+        metrics.sealed_segment_truncations.get(),
+        1,
+        "expected one sealed-segment truncation to be recorded"
+      );
+
+      // Reads of the corrupted segment terminate at the last validated
+      // entry, so a sweep over the full range returns fewer entries than
+      // were originally appended. The active segment is untouched, so its
+      // entries remain visible — `last_seq()` reports the highest seq, but
+      // the *count* visited is short by the entries lost past the
+      // corruption boundary.
+      let mut visitor = CollectingVisitor::new();
+      let visited = log.read(1, 1_000, &mut visitor).await.unwrap();
+      assert!(
+        (visited as u64) < appended,
+        "visited ({visited}) should be fewer than appended ({appended}) after sealed corruption"
+      );
     }
   }
 

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -937,10 +937,17 @@ impl Inner {
       if self.segments[0].last_seq < retain_from {
         // Drop the segment (and its mmap) before deleting the underlying files.
         let removed = self.segments.remove(0);
+        let log_path = self.segment_log_path(removed.first_seq);
+        let idx_path = self.segment_idx_path(removed.first_seq);
+        // Use the on-disk file size for the evicted-bytes metric so that
+        // truncated sealed segments (where `removed.file_size == valid_size`,
+        // smaller than the physical file) still report the actual disk space
+        // reclaimed. Fall back to `removed.file_size` if stat fails.
+        let physical_size = compio::fs::metadata(&log_path).await.map(|m| m.len()).unwrap_or(removed.file_size);
         self.metrics.segments_evicted.inc();
-        self.metrics.evicted_bytes.inc_by(removed.file_size);
-        let _ = compio::fs::remove_file(self.segment_log_path(removed.first_seq)).await;
-        let _ = compio::fs::remove_file(self.segment_idx_path(removed.first_seq)).await;
+        self.metrics.evicted_bytes.inc_by(physical_size);
+        let _ = compio::fs::remove_file(log_path).await;
+        let _ = compio::fs::remove_file(idx_path).await;
       } else {
         break;
       }
@@ -1911,8 +1918,9 @@ mod tests {
       log.flush().await.unwrap();
     }
 
-    // Truncation counter is per-recovery; the *first* recovery saw clean
-    // segments, so it must still be zero.
+    // The shared truncation counter is incremented during recovery when a
+    // sealed segment is truncated. The first recovery saw clean segments,
+    // so it must still be zero here.
     assert_eq!(metrics.sealed_segment_truncations.get(), 0);
 
     let channel_dir = {

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -935,7 +935,6 @@ impl Inner {
     // segment to append into.
     while self.segments.len() > 1 {
       if self.segments[0].last_seq < retain_from {
-        // Drop the segment (and its mmap) before deleting the underlying files.
         let removed = self.segments.remove(0);
         let log_path = self.segment_log_path(removed.first_seq);
         let idx_path = self.segment_idx_path(removed.first_seq);
@@ -943,9 +942,15 @@ impl Inner {
         // truncated sealed segments (where `removed.file_size == valid_size`,
         // smaller than the physical file) still report the actual disk space
         // reclaimed. Fall back to `removed.file_size` if stat fails.
-        let physical_size = compio::fs::metadata(&log_path).await.map(|m| m.len()).unwrap_or(removed.file_size);
+        let fallback_size = removed.file_size;
+        let physical_size = compio::fs::metadata(&log_path).await.map(|m| m.len()).unwrap_or(fallback_size);
         self.metrics.segments_evicted.inc();
         self.metrics.evicted_bytes.inc_by(physical_size);
+        // Explicitly drop the segment (and its idx mmap) before unlinking
+        // the underlying files. Linux is fine with unlinking a mapped file,
+        // but releasing the mapping first keeps the eviction safe on
+        // platforms where unlink fails while a mapping is alive.
+        drop(removed);
         let _ = compio::fs::remove_file(log_path).await;
         let _ = compio::fs::remove_file(idx_path).await;
       } else {

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -1944,11 +1944,7 @@ mod tests {
     {
       let log = create_log_with_segment_max_and_metrics(tmp.path(), 4096, metrics.clone()).await;
       // Recovery should have detected the truncation on the sealed segment.
-      assert_eq!(
-        metrics.sealed_segment_truncations.get(),
-        1,
-        "expected one sealed-segment truncation to be recorded"
-      );
+      assert_eq!(metrics.sealed_segment_truncations.get(), 1, "expected one sealed-segment truncation to be recorded");
 
       // Reads of the corrupted segment terminate at the last validated
       // entry, so a sweep over the full range returns fewer entries than

--- a/docs/architecture/MESSAGE_LOG.md
+++ b/docs/architecture/MESSAGE_LOG.md
@@ -636,15 +636,17 @@ start of recovery and reused across all segments to avoid per-segment allocation
    │   `.idx`'s last entry could be used to bound the scan, but the current
    │   implementation does not exploit this. Segments with zero valid
    │   entries are deleted.
-   │   If `valid_size < file_size` (CRC failed mid-segment, i.e. bit rot
-   │   or other on-disk corruption past the first entry), increment the
+   │   If `valid_size < file_size` (the validation scan terminated before
+   │   EOF — a CRC mismatch, an unreadable header, oversized declared
+   │   lengths, a truncated tail, or an I/O error), increment the
    │   `message_log_sealed_segment_truncations_total` counter and emit a
    │   `tracing::warn!` carrying the path, file size, valid size and last
    │   valid seq. The segment is registered with `file_size = valid_size`
-   │   so subsequent reads stop at the last validated entry; entries past
-   │   the corruption boundary remain on disk but are unreachable. This
+   │   so subsequent reads stop at the last validated entry; bytes past
+   │   the validated region remain on disk but are unreachable. This
    │   surfaces silent data loss to operators rather than letting it be
-   │   discovered later via missing history.
+   │   discovered later via missing history. The `crc_failures` counter
+   │   narrows the root cause to CRC mismatches specifically.
    ├─ .idx looks valid? → memory-map read-only (Mmap)
    └─ .idx missing or visibly corrupt? → rebuild by scanning .log with
    │                   EntryReader, then atomically replace the `.idx`:

--- a/docs/architecture/MESSAGE_LOG.md
+++ b/docs/architecture/MESSAGE_LOG.md
@@ -594,12 +594,21 @@ start of recovery and reused across all segments to avoid per-segment allocation
 
 2. For each sealed segment (all except the last):
    ├─ Zero-byte .log → delete .log + .idx and skip to the next segment.
-   ├─ Scan .log end-to-end with EntryReader (CRC validation) to determine last_seq.
-   │   This is a full-segment linear scan — recovery cost is therefore O(total
-   │   sealed bytes) per channel. The `.idx`'s last entry could be used to
-   │   bound the scan to roughly `INDEX_INTERVAL_BYTES + max_entry_size`
-   │   bytes, but the current implementation does not exploit this.
-   │   Segments with zero valid entries are deleted.
+   ├─ Scan .log end-to-end with EntryReader (CRC validation) to determine
+   │   `(last_seq, valid_size)`. This is a full-segment linear scan —
+   │   recovery cost is therefore O(total sealed bytes) per channel. The
+   │   `.idx`'s last entry could be used to bound the scan, but the current
+   │   implementation does not exploit this. Segments with zero valid
+   │   entries are deleted.
+   │   If `valid_size < file_size` (CRC failed mid-segment, i.e. bit rot
+   │   or other on-disk corruption past the first entry), increment the
+   │   `message_log_sealed_segment_truncations_total` counter and emit a
+   │   `tracing::warn!` carrying the path, file size, valid size and last
+   │   valid seq. The segment is registered with `file_size = valid_size`
+   │   so subsequent reads stop at the last validated entry; entries past
+   │   the corruption boundary remain on disk but are unreachable. This
+   │   surfaces silent data loss to operators rather than letting it be
+   │   discovered later via missing history.
    ├─ .idx looks valid? → memory-map read-only (Mmap)
    └─ .idx missing or visibly corrupt? → rebuild by scanning .log with
    │                   EntryReader, then atomically replace the `.idx`:


### PR DESCRIPTION
## Summary

A CRC failure mid-way through a sealed segment was silent data loss: recovery's `scan_last_seq` returned the last valid seq before the corruption and reads stopped there, but the segment's on-disk `file_size` stayed unchanged and there was no operator-visible signal. Bit rot or other on-disk corruption past the first entry of a sealed segment would quietly produce missing history with no telemetry — operators would discover it only through user reports of \"messages disappearing.\"

This is distinct from the documented \"subtle index corruption\" failure mode: that one's about a bad `.idx` offset pointing into well-formed log bytes (CRC trips, valid entries past the failure are skipped *for that read* but still on disk and reachable on the next recovery's index rebuild). The case fixed here is the `.log` itself being damaged on disk, which is permanent.

### Changes

Recovery now uses `scan_and_validate` directly for sealed segments and compares `valid_size` to the on-disk `file_size`. When they differ:

- Increment a new counter, `message_log_sealed_segment_truncations_total`, registered alongside the other `MessageLogMetrics` counters and zeroed in `MessageLogMetrics::noop()` for tests.
- Emit a `tracing::warn!` carrying `path`, `file_size`, `valid_size`, `last_valid_seq`, and `lost_bytes` so operators can wire alerts off either signal.
- Register the segment with `file_size = valid_size`, so subsequent reads stop at the last validated entry instead of attempting to decode the corrupt tail.

`scan_last_seq` was a thin wrapper around `scan_and_validate` that discarded `valid_size`, so this PR removes it — the new check falls out naturally.

### Test

`test_recovery_increments_metric_on_sealed_segment_corruption`:
1. Roll several sealed segments with a small `segment_max_bytes`.
2. Flip a byte deep inside the first sealed segment.
3. Re-open with a shared `MessageLogMetrics` handle.
4. Assert the truncation counter is `1` and a full-range read returns fewer entries than were appended.

(A small helper `create_log_with_segment_max_and_metrics` is added so tests can observe metric increments without registering a real `Registry`.)

## Test plan

- [x] `cargo test -p narwhal-server --lib channel::file_message_log` — 33 tests pass (32 prior + 1 new).
- [x] `cargo test -p narwhal-server` — full crate suite still green.
- [ ] Confirm the new counter is reachable from the existing `Registry` wiring (it's registered in `MessageLogMetrics::register` like its siblings, so it will show up under the same `narwhal` prefix as the other `message_log_*` counters).