### PR TITLE
fix(test-util): raise soft fd limit at suite construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,6 +1414,7 @@ dependencies = [
  "narwhal-server",
  "narwhal-util",
  "prometheus-client",
+ "rlimit",
  "rustls",
  "rustls-pki-types",
  "webpki-roots",

--- a/crates/test-util/Cargo.toml
+++ b/crates/test-util/Cargo.toml
@@ -18,6 +18,7 @@ narwhal-common = { path = "../common" }
 narwhal-modulator = { path = "../modulator" }
 narwhal-protocol = { path = "../protocol", features = ["serde"] }
 prometheus-client = "0.24"
+rlimit = "0.11.0"
 narwhal-server = { path = "../server" }
 narwhal-util = { path = "../util" }
 pki-types = { package = "rustls-pki-types", version = "1" }

--- a/crates/test-util/src/c2s_suite.rs
+++ b/crates/test-util/src/c2s_suite.rs
@@ -98,6 +98,8 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> C2sSuite<CS, MLF> {
     channel_store: CS,
     message_log_factory: MLF,
   ) -> anyhow::Result<Self> {
+    crate::raise_fd_limit();
+
     let arc_config = Arc::new(config);
 
     // Bootstrap the core dispatcher first.

--- a/crates/test-util/src/lib.rs
+++ b/crates/test-util/src/lib.rs
@@ -16,11 +16,36 @@ pub use s2m_suite::{S2mSuite, default_s2m_config_with_secret};
 use std::cell::UnsafeCell;
 use std::io::Cursor;
 use std::rc::Rc;
+use std::sync::Once;
 use std::time::Duration;
 
 use anyhow::anyhow;
 use narwhal_protocol::{Message, deserialize, serialize};
 use narwhal_util::pool::MutablePoolBuffer;
+
+/// Raises the soft `RLIMIT_NOFILE` to the current hard limit, once per process.
+///
+/// Integration tests in this workspace each spin up a full server (TLS
+/// listener per worker, file-backed channel store, segmented file message
+/// log). Running the test suite in parallel with the default soft limit of
+/// 1024 fds blows past the cap and surfaces as `Too many open files`
+/// failures. Bumping the soft limit to the hard limit lets the standard
+/// `cargo test` invocation succeed without requiring contributors to set
+/// `ulimit -n` manually.
+///
+/// Idempotent: subsequent calls are no-ops via [`Once`]. Best-effort: if
+/// the syscall fails (e.g. permissions, unsupported platform), tests still
+/// run and either pass or surface the underlying limit explicitly.
+pub fn raise_fd_limit() {
+  static ONCE: Once = Once::new();
+  ONCE.call_once(|| {
+    if let Ok((soft, hard)) = rlimit::getrlimit(rlimit::Resource::NOFILE)
+      && soft < hard
+    {
+      let _ = rlimit::setrlimit(rlimit::Resource::NOFILE, hard, hard);
+    }
+  });
+}
 
 /// A testing macro for asserting that a message matches an expected type and parameters.
 ///

--- a/crates/test-util/src/m2s_suite.rs
+++ b/crates/test-util/src/m2s_suite.rs
@@ -37,6 +37,8 @@ impl M2sSuite {
   ///
   /// This is `async` because `ConnRuntime::new` (conn) is async.
   pub async fn with_config(config: narwhal_modulator::M2sServerConfig) -> Self {
+    crate::raise_fd_limit();
+
     let arc_config = Arc::new(config);
 
     // Create the broadcast channel for outbound payloads

--- a/crates/test-util/src/s2m_suite.rs
+++ b/crates/test-util/src/s2m_suite.rs
@@ -30,6 +30,8 @@ impl<M: Modulator> S2mSuite<M> {
   ///
   /// This is `async` because `ConnRuntime::new` (conn) is async.
   pub async fn with_config(config: narwhal_modulator::S2mServerConfig, modulator: M) -> Self {
+    crate::raise_fd_limit();
+
     let arc_config = Arc::new(config);
 
     let mut registry = Registry::default();


### PR DESCRIPTION
## Summary

Closes #271.

Each integration test in `crates/server/tests/c2s_channel_persistence.rs` spins up a full server (TLS listener per worker, file-backed channel store, segmented file message log). Running the 17 tests in parallel under the typical Linux default soft `RLIMIT_NOFILE` of 1024 blows past the cap and surfaces as `Too many open files (os error 24)` plus downstream protocol-assertion mismatches when the server fails to accept a connection.

This PR mirrors the production server's `set_file_descriptor_limit` pattern (`crates/server/src/lib.rs:266`): at the start of each test suite constructor, raise the soft `RLIMIT_NOFILE` to the hard limit. Idempotent via `std::sync::Once`; best-effort (silent fallthrough if `setrlimit` fails).