### PR TITLE
fix(server): reject persistent channels with zero max_persist_messages

### DIFF
--- a/crates/server/src/c2s/config.rs
+++ b/crates/server/src/c2s/config.rs
@@ -249,7 +249,7 @@ fn default_payload_pool_memory_budget() -> u64 {
 }
 
 fn default_max_persist_messages() -> u32 {
-  100
+  1000
 }
 
 fn default_max_message_flush_interval() -> u32 {

--- a/crates/server/src/channel/manager.rs
+++ b/crates/server/src/channel/manager.rs
@@ -667,7 +667,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       let config = ChannelConfig {
         max_clients: Some(self.limits.max_clients_per_channel),
         max_payload_size: Some(self.limits.max_payload_size),
-        max_persist_messages: Some(0),
+        max_persist_messages: Some(self.limits.max_persist_messages),
         persist: Some(false),
         message_flush_interval: Some(0),
       };
@@ -986,7 +986,13 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
 
     let max_payload_size = channel.config.max_payload_size.unwrap_or(0);
     let is_persistent = channel.config.persist == Some(true);
-    let max_persist_messages = channel.config.max_persist_messages.unwrap_or(0);
+    // Defensive backstop: a persistent channel restored from a pre-validation
+    // store could carry max_persist_messages=0; coerce to the server limit so
+    // the eviction loophole stays closed for legacy on-disk state.
+    let max_persist_messages = match channel.config.max_persist_messages.unwrap_or(0) {
+      0 => self.limits.max_persist_messages,
+      v => v,
+    };
     let allowed_targets = channel.allowed_targets.clone();
     let seq = channel.next_seq();
     let payload_length = payload.as_slice().len() as u32;
@@ -1259,6 +1265,15 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       config.message_flush_interval.is_some() && config.message_flush_interval != channel.config.message_flush_interval;
     let new_config = channel.config.merge(&config);
     let is_persistent = new_config.persist == Some(true);
+
+    if is_persistent && new_config.max_persist_messages.unwrap_or(0) == 0 {
+      return Err(
+        narwhal_protocol::Error::new(BadRequest)
+          .with_id(correlation_id)
+          .with_detail("max_persist_messages must be greater than 0 for persistent channels")
+          .into(),
+      );
+    }
 
     if is_persistent {
       let mut projected = channel.to_persisted();

--- a/crates/server/tests/c2s_channel_persistence.rs
+++ b/crates/server/tests/c2s_channel_persistence.rs
@@ -7,11 +7,12 @@ use narwhal_modulator::create_s2m_listener;
 use narwhal_modulator::modulator::{AuthResult, ForwardBroadcastPayloadResult};
 use narwhal_protocol::{
   ChannelSeqParameters, ErrorParameters, ErrorReason, HistoryParameters, ListChannelsParameters, Message,
+  SetChannelConfigurationParameters,
 };
 use narwhal_server::channel::NoopMessageLogFactory;
 use narwhal_server::channel::file_message_log::{FileMessageLogFactory, MessageLogMetrics};
 use narwhal_server::channel::file_store::FileChannelStore;
-use narwhal_test_util::{C2sSuite, TestModulator, default_c2s_config, default_s2m_config};
+use narwhal_test_util::{C2sSuite, TestModulator, assert_message, default_c2s_config, default_s2m_config};
 use narwhal_util::string_atom::StringAtom;
 use prometheus_client::registry::Registry;
 
@@ -112,6 +113,52 @@ async fn test_c2s_file_channel_store_persists_and_restores_channel() -> anyhow::
     s2m_ln.shutdown().await?;
     s2m_dispatcher.shutdown().await?;
   }
+
+  Ok(())
+}
+
+/// Verifies that enabling persist=true with max_persist_messages=0
+/// is rejected with BadRequest, since unbounded retention is not
+/// a valid client-facing configuration.
+#[compio::test]
+async fn test_c2s_set_persist_with_zero_max_persist_messages_rejected() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = NoopMessageLogFactory;
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  suite.auth(TEST_USER_1, TEST_USER_1).await?;
+  suite.join_channel(TEST_USER_1, CHANNEL, None).await?;
+
+  suite
+    .write_message(
+      TEST_USER_1,
+      Message::SetChannelConfiguration(SetChannelConfigurationParameters {
+        id: 7777,
+        channel: StringAtom::from(CHANNEL),
+        persist: Some(true),
+        max_persist_messages: Some(0),
+        ..Default::default()
+      }),
+    )
+    .await?;
+
+  assert_message!(
+    suite.read_message(TEST_USER_1).await?,
+    Message::Error,
+    ErrorParameters {
+      id: Some(7777),
+      reason: ErrorReason::BadRequest.into(),
+      detail: Some(StringAtom::from("max_persist_messages must be greater than 0 for persistent channels")),
+    }
+  );
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
 
   Ok(())
 }

--- a/crates/server/tests/c2s_channel_persistence_failure.rs
+++ b/crates/server/tests/c2s_channel_persistence_failure.rs
@@ -333,7 +333,7 @@ async fn test_c2s_set_config_fails_when_store_save_fails() -> anyhow::Result<()>
       channel: StringAtom::from(CHANNEL),
       max_clients: 5,
       max_payload_size: 1024,
-      max_persist_messages: 0,
+      max_persist_messages: default_c2s_config().limits.max_persist_messages,
       persist: true,
       message_flush_interval: 0,
     }

--- a/crates/server/tests/c2s_tests.rs
+++ b/crates/server/tests/c2s_tests.rs
@@ -1219,7 +1219,10 @@ async fn test_c2s_channel_max_payload_configuration_limit() -> anyhow::Result<()
 
 #[compio::test]
 async fn test_c2s_channel_max_persist_messages_configuration_limit() -> anyhow::Result<()> {
-  let mut suite = C2sSuite::new(default_c2s_config()).await?;
+  let mut config = default_c2s_config();
+  config.limits.max_persist_messages = 100;
+
+  let mut suite = C2sSuite::new(config).await?;
   suite.setup().await?;
 
   // Identify users.
@@ -1228,7 +1231,7 @@ async fn test_c2s_channel_max_persist_messages_configuration_limit() -> anyhow::
   // Create a channel.
   suite.join_channel(TEST_USER_1, "!test1@localhost", None).await?;
 
-  // Set max_persist_messages above the server limit (default: 100).
+  // Set max_persist_messages above the configured server limit.
   suite
     .write_message(
       TEST_USER_1,

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -374,7 +374,7 @@ Acknowledges a connection request and provides server capabilities.
 
 **Example**:
 ```
-CONNECT_ACK auth_required=true heartbeat_interval=30000 max_subscriptions=100 max_message_size=4096 max_payload_size=1048576 max_inflight_requests=10 max_persist_messages=100
+CONNECT_ACK auth_required=true heartbeat_interval=30000 max_subscriptions=100 max_message_size=4096 max_payload_size=1048576 max_inflight_requests=10 max_persist_messages=1000
 ```
 
 ---


### PR DESCRIPTION
## Summary
- A channel configured with `persist = true` and `max_persist_messages = 0` previously bypassed the server-level cap (`c2s.limits.max_persist_messages`) and got unbounded retention, since `FileMessageLog::evict_segments` and the `ChannelStore` trait treat `0` as "no eviction". The validation at `set_channel_configuration` only rejected values *greater than* the cap, so `0` slipped through.
- Fail closed: validate the merged config in `set_channel_configuration` and return `BadRequest` when a persistent channel would have `max_persist_messages = 0`. The trait-level "0 disables eviction" semantics is preserved for internal/admin callers; only the client-controlled config path is tightened.
- Seed newly created channels with `max_persist_messages = self.limits.max_persist_messages` (mirroring how `max_payload_size` is seeded). Clients that toggle `persist = true` without specifying retention now pick up the server default rather than the bypass value.
- Defensive backstop at the broadcast call site: a stored `max_persist_messages = 0` is coerced to the server limit at append time. New state cannot reach `0` (validation prevents it), but the coercion keeps the loophole closed for any persistent channel that might be restored from a pre-validation on-disk format.
- Bump the server-level default from 100 to 1000 for a roomier out-of-the-box retention budget. Updated `docs/PROTOCOL.md` example accordingly.

