### PR TITLE
feat(benchmark): support running through an auth modulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/agent-context
+/data
 /examples/modulator/target
 /target
 profile.json.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,6 +1243,8 @@ dependencies = [
  "anyhow",
  "async-channel",
  "async-lock",
+ "async-trait",
+ "base64 0.21.7",
  "clap",
  "compio",
  "compio-tls",

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ cargo build --bin narwhal-bench --release
   --producers 1 \
   --consumers 1 \
   --duration 1m \
-  --max-payload-size 256
+  --payload-size 256
 ```
 
 The benchmark tool simulates multiple producer and consumer clients connecting to a Narwhal server and exchanging messages. It reports metrics such as:
@@ -170,6 +170,22 @@ The benchmark tool simulates multiple producer and consumer clients connecting t
 - Latency percentiles (p50, p90, p99)
 - Connection success rates
 - Total messages sent and received
+
+#### Benchmarking persistent channels
+
+Pass `--persist` to make the bench enable persistence on its channel before broadcasting. Every broadcast then writes to the channel's append-only message log and is acknowledged only after the log is flushed, so steady-state throughput becomes bounded by single-flush latency rather than the network/dispatch path.
+
+```bash
+./target/release/narwhal-bench \
+  --server 127.0.0.1:22622 \
+  --producers 1 \
+  --consumers 1 \
+  --duration 1m \
+  --payload-size 8192 \
+  --persist
+```
+
+Inspect the `narwhal_message_log_flush_duration_seconds` histogram on the server's `/metrics` endpoint to see the dominant cost.
 
 ### Running with Debug Tracing
 

--- a/crates/benchmark/Cargo.toml
+++ b/crates/benchmark/Cargo.toml
@@ -12,6 +12,8 @@ path = "src/main.rs"
 anyhow = "1.0.101"
 async-channel = "2.5.0"
 async-lock = "3.4.2"
+async-trait = "0.1.88"
+base64 = "0.21"
 clap = { version = "4.5.59", features = ["derive"] }
 compio = { version = "0.18", features = ["runtime", "time", "net", "io", "macros"] }
 compio-tls = { version = "0.9", features = ["rustls"] }

--- a/crates/benchmark/src/main.rs
+++ b/crates/benchmark/src/main.rs
@@ -11,8 +11,10 @@ use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt, select};
 
 use async_lock::Mutex;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use narwhal_client::compio::c2s::C2sClient;
-use narwhal_client::{AuthMethod, C2sConfig};
+use narwhal_client::{AuthMethod, Authenticator, AuthenticatorFactory, C2sConfig};
 use narwhal_protocol::Nid;
 use narwhal_protocol::{AclAction, AclType, QoS};
 use narwhal_util::pool::Pool;
@@ -54,6 +56,12 @@ struct Cli {
   /// Enable message persistence on the benchmark channels
   #[arg(long, default_value_t = false)]
   persist: bool,
+
+  /// PLAIN auth password. When set, clients authenticate via the AUTH command using their
+  /// generated bench username and this password (suitable for the `plain-authenticator`
+  /// example modulator). When unset, clients use the IDENTIFY command (no modulator).
+  #[arg(long)]
+  auth_password: Option<String>,
 }
 
 /// Parse duration from string (supports: 30s, 5m, 1h)
@@ -85,6 +93,7 @@ fn main() {
   info!("channel(s): {}", cli.channels);
   info!("duration: {:?}", cli.duration);
   info!("persist: {}", cli.persist);
+  info!("auth: {}", if cli.auth_password.is_some() { "PLAIN" } else { "IDENTIFY" });
 
   // Initialize compio runtime
   compio::runtime::RuntimeBuilder::new().build().unwrap().block_on(async {
@@ -318,17 +327,63 @@ async fn create_and_join_channel(
   Ok(channel)
 }
 
+/// Single-step PLAIN authenticator. Emits a base64-encoded `\0username\0password` token.
+struct PlainAuthenticator {
+  username: String,
+  password: String,
+}
+
+#[async_trait::async_trait]
+impl Authenticator for PlainAuthenticator {
+  async fn start(&mut self) -> anyhow::Result<String> {
+    let mut token = Vec::with_capacity(self.username.len() + self.password.len() + 2);
+    token.push(0);
+    token.extend_from_slice(self.username.as_bytes());
+    token.push(0);
+    token.extend_from_slice(self.password.as_bytes());
+    Ok(BASE64_STANDARD.encode(token))
+  }
+
+  async fn next(&mut self, _challenge: String) -> anyhow::Result<String> {
+    anyhow::bail!("PLAIN is single-step; unexpected challenge from server")
+  }
+}
+
+struct PlainAuthenticatorFactory {
+  username: String,
+  password: String,
+}
+
+impl AuthenticatorFactory for PlainAuthenticatorFactory {
+  fn create(&self) -> Box<dyn Authenticator> {
+    Box::new(PlainAuthenticator { username: self.username.clone(), password: self.password.clone() })
+  }
+}
+
 /// Creates multiple clients with the given configuration.
 ///
 /// Returns a tuple of (clients, successful_count, failed_count).
-fn create_clients(config: &C2sConfig, count: usize, client_type: &str) -> (Vec<C2sClient>, usize, usize) {
+fn create_clients(
+  config: &C2sConfig,
+  count: usize,
+  client_type: &str,
+  auth_password: Option<&str>,
+) -> (Vec<C2sClient>, usize, usize) {
   let mut clients = Vec::with_capacity(count);
   let mut successful = 0;
   let mut failed = 0;
 
   for i in 0..count {
     let username = format!("bench_{}_{}", client_type, i);
-    let auth_method = AuthMethod::Identify { username: username.as_str().into() };
+    let auth_method = match auth_password {
+      Some(password) => AuthMethod::Auth {
+        authenticator_factory: Arc::new(PlainAuthenticatorFactory {
+          username: username.clone(),
+          password: password.to_string(),
+        }),
+      },
+      None => AuthMethod::Identify { username: username.as_str().into() },
+    };
 
     match C2sClient::new_with_insecure_tls(config.clone(), auth_method) {
       Ok(client) => {
@@ -500,12 +555,12 @@ async fn perform_benchmark(cli: &Cli, metrics: &mut BenchmarkMetrics) -> Result<
   // Create producers
   info!("creating {} producer client(s)...", cli.producers);
   let (producer_clients, producer_successful, producer_failed) =
-    create_clients(&client_config, cli.producers, "producer");
+    create_clients(&client_config, cli.producers, "producer", cli.auth_password.as_deref());
 
   // Create consumers
   info!("creating {} consumer client(s)...", cli.consumers);
   let (consumer_clients, consumer_successful, consumer_failed) =
-    create_clients(&client_config, cli.consumers, "consumer");
+    create_clients(&client_config, cli.consumers, "consumer", cli.auth_password.as_deref());
 
   // Combine metrics from producers and consumers
   let successful = producer_successful + consumer_successful;

--- a/crates/modulator/src/config.rs
+++ b/crates/modulator/src/config.rs
@@ -261,6 +261,7 @@ impl Default for ServerConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Limits {
   /// The maximum number of connections to accept.
   pub max_connections: u32,

--- a/examples/config/c2s-benchmark-with-s2m-unix.toml
+++ b/examples/config/c2s-benchmark-with-s2m-unix.toml
@@ -1,0 +1,45 @@
+# Configuration for benchmarking Narwhal's C2S performance with an S2M modulator
+# attached over a Unix domain socket. Mirrors `c2s-benchmark.toml` but routes auth
+# through a modulator (e.g. the `plain-authenticator` example).
+#
+# The companion modulator config is `s2m-minimal-unix.toml`, which makes the
+# modulator listen on `/tmp/narwhal-s2m-server.sock`.
+
+[c2s-server.limits]
+# Maximum message size in bytes (32KB).
+max_message_size = 32768
+
+# Maximum payload size in bytes (128KB).
+max_payload_size = 131072
+
+# Payload pool memory budget in bytes (4GB).
+payload_pool_memory_budget = 4294967296
+
+# Maximum number of clients allowed per channel.
+max_clients_per_channel = 1000
+
+# Maximum number of inflight requests per client.
+max_inflight_requests = 100
+
+# When running benchmarks locally, set the outbound message queue size to a high value
+# to prevent disconnects due to outbound queue overflow.
+outbound_message_queue_size = 262144
+
+# Disable rate limiting completely to prevent artificial throughput caps.
+rate_limit = 0
+
+# Modulator configuration.
+[modulator]
+type = "s2m"
+
+# S2M client configuration.
+#
+# The C2S server connects out to a modulator listening on this Unix socket
+# (e.g. `plain-authenticator` started with `s2m-minimal-unix.toml`).
+[modulator.s2m-client]
+network = "unix"
+socket_path = "/tmp/narwhal-s2m-server.sock"
+
+# NOTE: `[modulator.m2s-server.listener]` is intentionally omitted. It is only
+# needed if the modulator implements `ReceivePrivatePayload`, which the
+# `plain-authenticator` example does not.

--- a/examples/config/c2s-benchmark.toml
+++ b/examples/config/c2s-benchmark.toml
@@ -1,9 +1,5 @@
 # This configuration file is designed for benchmarking Narwhal's C2S performance.
 
-# Enable console logging for telemetry
-# [telemetry.console]
-# enabled = true
-
 [c2s-server.limits]
 # Maximum message size in bytes (32KB).
 max_message_size = 32768

--- a/examples/config/s2m-benchmark-unix.toml
+++ b/examples/config/s2m-benchmark-unix.toml
@@ -1,0 +1,22 @@
+# Configuration for an S2M modulator paired with `c2s-benchmark-with-s2m-unix.toml`.
+# Mirrors `s2m-minimal-unix.toml` but raises the s2m-side message/payload limits to
+# match the c2s-side bench tuning, so the C2S server's `max_message_size` ceiling
+# is not dragged down at session-info negotiation time.
+#
+# NOTE: `[m2s-client]` is intentionally omitted. It is only required when the
+# modulator implements `ReceivePrivatePayload` (i.e. needs the S2M server to push
+# payloads back through an M2S client). The `plain-authenticator` example is
+# auth-only and does not.
+
+# S2M server configuration.
+[server.listener]
+network = "unix"
+socket_path = "/tmp/narwhal-s2m-server.sock"
+
+# Raised limits to keep the s2m session from clamping the C2S `max_message_size`
+# below what the bench config asks for.
+[server.limits]
+# Match the c2s benchmark config (32 KiB).
+max_message_size = 32768
+# Match the c2s benchmark config (128 KiB).
+max_payload_size = 131072

--- a/examples/modulator/plain-authenticator/src/main.rs
+++ b/examples/modulator/plain-authenticator/src/main.rs
@@ -26,7 +26,6 @@ use prometheus_client::registry::Registry;
 
 const MODULATOR_PROTOCOL_NAME: &str = "plain-authenticator/1.0";
 
-const USERNAME: &str = "user";
 const PASSWORD: &str = "pass";
 
 /// A simple PLAIN authentication modulator.
@@ -34,11 +33,12 @@ const PASSWORD: &str = "pass";
 /// This modulator implements the `Modulator` trait and performs authentication using the PLAIN mechanism.
 /// It expects the authentication token to be a base64-encoded string of the form `\0username\0password`.
 ///
-/// The username and password are checked against hardcoded values for demonstration purposes:
-///   - Username: `user`
+/// Any non-empty username is accepted. The password is checked against a hardcoded value for
+/// demonstration purposes:
 ///   - Password: `pass`
 ///
-/// If the credentials match, authentication succeeds and the username is returned. Otherwise, authentication fails.
+/// If the password matches, authentication succeeds and the client-supplied username is returned.
+/// Otherwise, authentication fails.
 ///
 /// Example token for username `user` and password `pass`:
 ///   - Raw: `\0user\0pass`
@@ -61,15 +61,15 @@ impl narwhal_modulator::Modulator for PlainAuthenticator {
   /// Authenticates a client using the PLAIN mechanism.
   ///
   /// The `token` parameter must be a base64-encoded string of the form `\0username\0password`.
-  /// If the username and password match the hardcoded values, authentication succeeds and the username is returned.
-  /// Otherwise, authentication fails.
+  /// Any non-empty username is accepted; the password must match the hardcoded value.
+  /// On success, the client-supplied username is returned.
   ///
   /// # Arguments
   /// * `token` - A base64-encoded PLAIN authentication token.
   ///
   /// # Returns
-  /// * `AuthResponse` with `AuthResult::Success` containing the username if credentials are valid.
-  /// * `AuthResponse` with `AuthResult::Failure` if credentials are invalid or the token is malformed.
+  /// * `AuthResponse` with `AuthResult::Success` containing the username if the password is valid.
+  /// * `AuthResponse` with `AuthResult::Failure` if the password is invalid or the token is malformed.
   async fn authenticate(&self, request: AuthRequest) -> anyhow::Result<AuthResponse> {
     // Decode base64 token
     let decoded = match BASE64_STANDARD.decode(request.token.as_ref()) {
@@ -89,10 +89,10 @@ impl narwhal_modulator::Modulator for PlainAuthenticator {
 
     match (username, password) {
       (Some(u), Some(p)) if !u.is_empty() && !p.is_empty() => {
-        if u == USERNAME && p == PASSWORD {
+        if p == PASSWORD {
           Ok(AuthResponse { result: AuthResult::Success { username: StringAtom::from(u) } })
         } else {
-          tracing::warn!("authentication failed: invalid username or password");
+          tracing::warn!("authentication failed: invalid password");
           Ok(AuthResponse { result: AuthResult::Failure })
         }
       },


### PR DESCRIPTION
> Stacked on top of #274. Once that merges, this PR's base will retarget to `main`.

## Summary
- Adds a `--auth-password` flag to `narwhal-bench`. When set, each client authenticates via the AUTH command (PLAIN) using its bench-generated `bench_<role>_<i>` username and the shared password — keeping the C2S router's per-username shard distribution intact while exercising the modulator-auth path. When unset, the existing IDENTIFY path is preserved.
- Relaxes the `plain-authenticator` example: any non-empty username is accepted, only the hardcoded `pass` password is validated. This avoids collapsing every bench client onto a single shard when running through the example modulator.
- Tags the modulator-side `Limits` struct with `#[serde(default)]` so a partial `[server.limits]` block no longer requires enumerating every field — matches the project-wide config convention noted in the codebase.
- Adds two new example configs: `c2s-benchmark-with-s2m-unix.toml` (bench-tuned C2S limits + S2M-client unix socket) and `s2m-benchmark-unix.toml` (paired modulator config with raised limits so the C2S `max_message_size` ceiling is not dragged down at session-info negotiation).
- README documents `--persist` runs under the benchmarking section and fixes a pre-existing `--max-payload-size` typo (the actual flag is `--payload-size`).

## Observed numbers (1p / 1c / 60s, on this branch, post-#275 server)

| Setup | Payload | msg/s | p50 | p99 |
|---|---|---|---|---|
| AUTH, no persist | 256 B | 163,497 | 0.62 ms | 0.83 ms |
| AUTH, no persist | 8 KiB | 69,267 | 1.42 ms | 1.73 ms |
| AUTH, persist | 256 B | 2,052 | 46.98 ms | 67.01 ms |
| AUTH, persist | 8 KiB | 1,125 | 86.66 ms | 109.50 ms |

Auth path adds effectively zero overhead vs. the no-modulator baseline. Persist runs are fsync-bound (avg flush ~0.47 ms at 256 B, ~0.87 ms at 8 KiB) which caps a single producer at \`1 / fsync_latency\` — observed throughput matches the math.