### PR TITLE
feat(benchmark): add --flush-interval-ms flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The benchmark tool simulates multiple producer and consumer clients connecting t
 
 #### Benchmarking persistent channels
 
-Pass `--persist` to make the bench enable persistence on its channel before broadcasting. Every broadcast then writes to the channel's append-only message log and is acknowledged only after the log is flushed, so steady-state throughput becomes bounded by single-flush latency rather than the network/dispatch path.
+Pass `--persist` to make the bench enable persistence on its channel before broadcasting. By default every broadcast writes to the channel's append-only message log and is acknowledged only after the log is flushed, so steady-state throughput becomes bounded by single-flush latency rather than the network/dispatch path.
 
 ```bash
 ./target/release/narwhal-bench \
@@ -185,7 +185,20 @@ Pass `--persist` to make the bench enable persistence on its channel before broa
   --persist
 ```
 
-Inspect the `narwhal_message_log_flush_duration_seconds` histogram on the server's `/metrics` endpoint to see the dominant cost.
+To trade strict per-message durability for higher throughput, add `--flush-interval-ms <N>`. The bench sets the channel's `message_flush_interval` via `SET_CHAN_CONFIG`, which switches the server from an inline flush per append to a background flush every `N` ms:
+
+```bash
+./target/release/narwhal-bench \
+  --server 127.0.0.1:22622 \
+  --producers 1 \
+  --consumers 1 \
+  --duration 1m \
+  --payload-size 8192 \
+  --persist \
+  --flush-interval-ms 100
+```
+
+Inspect the `narwhal_message_log_flush_duration_seconds` histogram on the server's `/metrics` endpoint to see the dominant cost in either mode.
 
 ### Running with Debug Tracing
 

--- a/crates/benchmark/src/main.rs
+++ b/crates/benchmark/src/main.rs
@@ -62,6 +62,14 @@ struct Cli {
   /// example modulator). When unset, clients use the IDENTIFY command (no modulator).
   #[arg(long)]
   auth_password: Option<String>,
+
+  /// Channel `message_flush_interval` in milliseconds, applied via SET_CHAN_CONFIG. Only
+  /// meaningful with --persist: 0 (server default) flushes after every append, gating the
+  /// producer ACK on durability; values >0 let an async background task flush at this interval,
+  /// trading "best-effort within N ms" durability for higher throughput. Server enforces an
+  /// upper bound via `max_message_flush_interval` (default 60 000 ms).
+  #[arg(long, requires = "persist")]
+  flush_interval_ms: Option<u32>,
 }
 
 /// Parse duration from string (supports: 30s, 5m, 1h)
@@ -93,6 +101,9 @@ fn main() {
   info!("channel(s): {}", cli.channels);
   info!("duration: {:?}", cli.duration);
   info!("persist: {}", cli.persist);
+  if let Some(v) = cli.flush_interval_ms {
+    info!("flush-interval-ms: {}", v);
+  }
   info!("auth: {}", if cli.auth_password.is_some() { "PLAIN" } else { "IDENTIFY" });
 
   // Initialize compio runtime
@@ -241,6 +252,7 @@ async fn create_and_join_channel(
   num_consumers: usize,
   channel_index: usize,
   persist: bool,
+  flush_interval_ms: Option<u32>,
 ) -> Result<StringAtom> {
   // Generate a unique channel name using the provided index
   let channel_id = format!("!bench{}@localhost", channel_index);
@@ -288,7 +300,7 @@ async fn create_and_join_channel(
   };
 
   if persist {
-    match clients[0].configure_channel(channel.clone(), None, None, None, Some(true), None).await {
+    match clients[0].configure_channel(channel.clone(), None, None, None, Some(true), flush_interval_ms).await {
       Ok(()) => {
         info!("channel persistence enabled: {}", channel);
       },
@@ -597,7 +609,9 @@ async fn perform_benchmark(cli: &Cli, metrics: &mut BenchmarkMetrics) -> Result<
     if cli.channels > 1 {
       info!("creating channel {} of {}...", i + 1, cli.channels);
     }
-    let channel = create_and_join_channel(&all_clients, cli.producers, cli.consumers, i + 1, cli.persist).await?;
+    let channel =
+      create_and_join_channel(&all_clients, cli.producers, cli.consumers, i + 1, cli.persist, cli.flush_interval_ms)
+        .await?;
     channels.push(channel);
   }
 


### PR DESCRIPTION
## Summary
- Adds a `--flush-interval-ms <U32>` flag to \`narwhal-bench\`. When combined with \`--persist\`, the bench applies the value as the channel's \`message_flush_interval\` via \`SET_CHAN_CONFIG\`, switching the server from an inline fsync per append to a background flush every N milliseconds. clap's \`requires = \"persist\"\` rejects the flag when persistence is off.
- Updates the README's \"Benchmarking persistent channels\" section to document both modes and point at the \`narwhal_message_log_flush_duration_seconds\` histogram for measuring the dominant cost.
- Depends on the actor-mailbox flush routing fix (#277, already merged): without that fix, this flag triggers a \`RefCell already borrowed\` panic on the server.

## Observed numbers (1p / 1c / 60 s, AUTH path through plain-authenticator over a unix socket)

| Payload | flush-interval | msg/s | p50 | p99 |
|---|---|---|---|---|
| 256 B | 0 (inline) | 2,052 | 46.98 ms | 67.01 ms |
| **256 B** | **100 ms** | **136,727** | **0.70 ms** | **1.18 ms** |
| 8 KiB | 0 (inline) | 1,125 | 86.66 ms | 109.50 ms |
| **8 KiB** | **100 ms** | **65,343** | **1.36 ms** | **8.97 ms** |

At \`--flush-interval-ms 100\` the bench recovers ~84% of the no-persist 256 B throughput (163,497 msg/s) while still flushing to disk every 100 ms; on the 8 KiB run, ~95% of the no-persist baseline. The trade-off the server-side knob has always exposed is now reachable from the bench.

