### PR TITLE
docs(agents): forbid em dashes and ellipses in comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,5 +26,6 @@ Whenever you modify, create, or delete Rust (`.rs`) files, you MUST follow this 
 4. **Completion:** Do not report that you are finished until `cargo fmt` has been run and `cargo clippy` returns a clean, zero-exit-code run with no warnings.
 
 ## 4. Comment Style Rule
-- No em dashes (—) in comments.
-- No ellipses (...) in comments.
+Apply this rule only to comment text that you newly add or modify as part of the current change.
+  - Do not use em dashes (—).
+  - Do not use ellipses, whether written as `...` or `…`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,7 @@ Whenever you modify, create, or delete Rust (`.rs`) files, you MUST follow this 
    - You may use `cargo clippy --fix --allow-dirty --allow-staged` if it helps resolve the issues faster.
    - You must re-run the `cargo clippy` command to verify the fix worked.
 4. **Completion:** Do not report that you are finished until `cargo fmt` has been run and `cargo clippy` returns a clean, zero-exit-code run with no warnings.
+
+## 4. Comment Style Rule
+- No em dashes (—) in comments.
+- No ellipses (...) in comments.


### PR DESCRIPTION
## Summary
- Add a comment-style rule to `AGENTS.md` forbidding em dashes (—) and ellipses (...) in comments.