### PR TITLE
chore: sweep em dashes and ellipses from comments and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ git checkout -b fix/issue-description
 Write clear, descriptive commit messages:
 
 - Use the present tense ("Add feature" not "Added feature")
-- Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+- Use the imperative mood ("Move cursor to." not "Moves cursor to.")
 - Limit the first line to 72 characters or less
 - Reference issues and pull requests when relevant
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ git checkout -b fix/issue-description
 Write clear, descriptive commit messages:
 
 - Use the present tense ("Add feature" not "Added feature")
-- Use the imperative mood ("Move cursor to." not "Moves cursor to.")
+- Use the imperative mood ("Move cursor to position X" not "Moves cursor to position X")
 - Limit the first line to 72 characters or less
 - Reference issues and pull requests when relevant
 

--- a/crates/benchmark/src/main.rs
+++ b/crates/benchmark/src/main.rs
@@ -474,7 +474,7 @@ async fn broadcast_messages(
           },
         }
 
-        // If we haven't reached the deadline... broadcast a new message
+        // If we haven't reached the deadline, broadcast a new message
         if Instant::now() < end_time {
           let task_channel = client_channels[channel_idx % client_channels.len()].clone();
           let task_client = client.clone();

--- a/crates/client/src/compio/common.rs
+++ b/crates/client/src/compio/common.rs
@@ -202,10 +202,10 @@ where
   ///
   /// # Arguments
   ///
-  /// * `client_id` — human-readable identifier (for logs).
-  /// * `config` — connection and retry settings.
-  /// * `dialer` — factory for new transport streams.
-  /// * `handshaker` — performs the protocol handshake on each new stream.
+  /// * `client_id`: human-readable identifier (for logs).
+  /// * `config`: connection and retry settings.
+  /// * `dialer`: factory for new transport streams.
+  /// * `handshaker`: performs the protocol handshake on each new stream.
   pub fn new(
     client_id: impl Into<String>,
     config: Config,
@@ -567,7 +567,7 @@ where
 
 /// A single connection to a Narwhal server, driven by compio.
 ///
-/// The struct itself is `Send` (it holds only `Arc`, channels, tokens, ...).
+/// The struct itself is `Send` (it holds only `Arc`, channels, tokens, etc.).
 /// The actual I/O tasks (reader + writer) live on the compio event loop of
 /// the thread that called [`connect`].
 struct ClientConn<S, HS, ST>
@@ -712,7 +712,7 @@ where
     Ok(())
   }
 
-  /// Signals cancellation — the reader / writer tasks will observe it and
+  /// Signals cancellation. The reader / writer tasks will observe it and
   /// exit on their own.
   async fn shutdown(&self) -> anyhow::Result<()> {
     self.shutdown_token.cancel();
@@ -777,7 +777,7 @@ where
               }
             },
             Err(_) => {
-              // All senders dropped — exit.
+              // All senders dropped, exit.
               break;
             },
           }
@@ -891,7 +891,7 @@ where
                       },
                     }
                   } else {
-                    // Unsolicited inbound message — no correlation id.
+                    // Unsolicited inbound message: no correlation id.
                     match res {
                       Ok((msg, payload_opt)) => {
                         if let Err(e) = inbound_tx.try_send((msg, payload_opt)) {

--- a/crates/client/src/compio/dialer.rs
+++ b/crates/client/src/compio/dialer.rs
@@ -144,7 +144,7 @@ impl Dialer for UnixDialer {
 /// The concrete stream type produced by [`TlsDialer`].
 pub type TlsStream = compio_tls::TlsStream<compio::net::TcpStream>;
 
-/// TLS dialer for compio — produces [`TlsStream`].
+/// TLS dialer for compio: produces [`TlsStream`].
 #[derive(Clone)]
 pub struct TlsDialer {
   address: String,

--- a/crates/client/src/conn_state.rs
+++ b/crates/client/src/conn_state.rs
@@ -53,7 +53,7 @@ pub(crate) struct PendingRequest {
   /// response arrives.
   pub sender: Option<ResponseSender>,
 
-  /// Owned semaphore permit — released when this entry is removed,
+  /// Owned semaphore permit, released when this entry is removed,
   /// allowing another request to be submitted.
   pub _permit: SemaphoreGuardArc,
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -6,11 +6,11 @@
 //!
 //! ## I/O Models
 //!
-//! Two runtime back-ends are available as public modules — pick the one that
+//! Two runtime back-ends are available as public modules. Pick the one that
 //! matches your application's async runtime:
 //!
-//! - **[`tokio`]** — poll/readiness-based (Tokio)
-//! - **[`compio`]** — completion-based (compio)
+//! - **[`tokio`]**: poll/readiness-based (Tokio)
+//! - **[`compio`]**: completion-based (compio)
 //!
 //! Import the client types you need directly from the corresponding module,
 //! e.g. `narwhal_client::tokio::c2s::C2sClient` or `narwhal_client::compio::c2s::C2sClient`.

--- a/crates/client/src/object_pool.rs
+++ b/crates/client/src/object_pool.rs
@@ -94,7 +94,7 @@ struct ObjectPoolInner<M: Manager> {
   /// Mutable pool state.
   state: Mutex<ObjectPoolState<M>>,
 
-  /// Semaphore with `max_size` permits — gates how many objects may be
+  /// Semaphore with `max_size` permits; gates how many objects may be
   /// checked out simultaneously.  Callers of [`ObjectPool::get`] acquire a
   /// permit; the permit is released when the [`ObjectPoolObject`] is dropped.
   semaphore: Arc<Semaphore>,
@@ -248,7 +248,7 @@ impl<M: Manager> ObjectPool<M> {
       }
     };
 
-    // Double-check after waking — the pool may have been closed while we
+    // Double-check after waking: the pool may have been closed while we
     // were waiting for the permit.
     if self.inner.state.lock().closed {
       // Permit is dropped here, releasing the slot.
@@ -264,7 +264,7 @@ impl<M: Manager> ObjectPool<M> {
             return Ok(ObjectPoolObject { inner: Some(obj), pool: Arc::clone(&self.inner), _permit: permit });
           },
           Err(_) => {
-            // Unhealthy — detach and try the next idle object.
+            // Unhealthy: detach and try the next idle object.
             self.inner.manager.detach(&mut obj);
             continue;
           },
@@ -347,13 +347,13 @@ impl<M: Manager> ObjectPool<M> {
 /// semaphore permit is released.  This ensures the next waiter always finds
 /// the object in the idle list.
 pub struct ObjectPoolObject<M: Manager> {
-  // Dropped first — taken in the manual `Drop` impl.
+  // Dropped first: taken in the manual `Drop` impl.
   inner: Option<M::Type>,
 
-  // Dropped second — `return_object` is called via this Arc.
+  // Dropped second: `return_object` is called via this Arc.
   pool: Arc<ObjectPoolInner<M>>,
 
-  // Dropped last — releasing the semaphore permit.
+  // Dropped last: releasing the semaphore permit.
   _permit: SemaphoreGuardArc,
 }
 
@@ -504,7 +504,7 @@ mod tests {
     compio::runtime::time::sleep(Duration::from_millis(50)).await;
     assert!(!done.load(Ordering::SeqCst), "spawned task should still be blocked");
 
-    // Return the object — releases the permit and wakes the waiter.
+    // Return the object: releases the permit and wakes the waiter.
     drop(obj);
 
     // Yield so the spawned task can complete.
@@ -577,7 +577,7 @@ mod tests {
     compio::runtime::time::sleep(Duration::from_millis(50)).await;
     assert!(!got_closed.load(Ordering::SeqCst));
 
-    // Close the pool — should immediately wake the blocked waiter.
+    // Close the pool: should immediately wake the blocked waiter.
     pool.close();
 
     // Yield so the spawned task can observe the close signal.
@@ -596,7 +596,7 @@ mod tests {
     let err = pool.get().await;
     assert!(matches!(err, Err(ObjectPoolError::Backend(_))));
 
-    // Slot should have been released — we can try again without blocking.
+    // Slot should have been released: we can try again without blocking.
     let err = pool.get().await;
     assert!(matches!(err, Err(ObjectPoolError::Backend(_))));
   }

--- a/crates/modulator/tests/m2s_tests.rs
+++ b/crates/modulator/tests/m2s_tests.rs
@@ -85,7 +85,7 @@ async fn test_m2s_max_connection_limit_reached() -> anyhow::Result<()> {
   let mut suite = M2sSuite::with_config(config).await;
   suite.setup().await?;
 
-  // Establish a first connection — keep it alive as a local variable.
+  // Establish a first connection, keeping it alive as a local variable.
   let _first = suite.socket_connect().await?;
 
   // Connect to the server again and expect an error.

--- a/crates/modulator/tests/s2m_tests.rs
+++ b/crates/modulator/tests/s2m_tests.rs
@@ -107,7 +107,7 @@ async fn test_s2m_max_connection_limit_reached() -> anyhow::Result<()> {
   let mut suite = S2mSuite::with_config(config, modulator).await;
   suite.setup().await?;
 
-  // Establish a first connection — keep it alive as a local variable.
+  // Establish a first connection, keeping it alive as a local variable.
   let _first = suite.socket_connect().await?;
 
   // Connect to the server again and expect an error.

--- a/crates/server/src/c2s/listener.rs
+++ b/crates/server/src/c2s/listener.rs
@@ -73,7 +73,7 @@ pub struct C2sListener<CS: ChannelStore, MLF: MessageLogFactory> {
   /// The local address of the listener.
   local_address: Option<SocketAddr>,
 
-  /// Shutdown senders for each accept loop — one per shard.
+  /// Shutdown senders for each accept loop, one per shard.
   shutdown_txs: Vec<Sender<()>>,
 
   /// Listener metrics.

--- a/crates/server/src/c2s/router.rs
+++ b/crates/server/src/c2s/router.rs
@@ -415,7 +415,7 @@ mod tests {
     let msg = Message::Ping(Default::default());
     router.route_to(msg, None, username.clone(), None).await.unwrap();
 
-    // Use has_connection as a barrier — it round-trips through the actor,
+    // Use has_connection as a barrier: it round-trips through the actor,
     // ensuring the prior RouteTo command has been processed.
     let _ = router.has_connection(&username).await;
 

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -45,7 +45,7 @@ const INDEX_EXT: &str = "idx";
 
 /// Metric handles for `FileMessageLog` operations.
 ///
-/// Cloneable — each `FileMessageLog` instance holds a clone, so a single set of
+/// Cloneable: each `FileMessageLog` instance holds a clone, so a single set of
 /// handles is shared across all logs created by a factory.
 #[derive(Clone)]
 pub struct MessageLogMetrics {
@@ -117,7 +117,7 @@ impl MessageLogMetrics {
     }
   }
 
-  /// Returns an instance with unregistered handles — useful for tests that do
+  /// Returns an instance with unregistered handles, useful for tests that do
   /// not care about observing metric values.
   pub fn noop() -> Self {
     Self {
@@ -406,7 +406,7 @@ impl Inner {
 
     // Tracks whether the last seg_seqs entry was successfully recovered as the
     // active segment. If false (e.g. zero-byte .log, or every entry failed CRC),
-    // we must NOT promote a preceding sealed segment to active — that would
+    // we must NOT promote a preceding sealed segment to active: that would
     // open a sealed .log for writes and double-map its .idx (read-only +
     // writable) to the same file.
     let mut active_segment_recovered = false;
@@ -426,7 +426,7 @@ impl Inner {
       };
 
       if file_size == 0 {
-        // Empty segment file — leftover from crash during roll.
+        // Empty segment file: leftover from crash during roll.
         let _ = compio::fs::remove_file(&log_path).await;
         let _ = compio::fs::remove_file(&idx_path).await;
         continue;
@@ -447,7 +447,7 @@ impl Inner {
           self.segments.push(SegmentInfo { first_seq: base_seq, last_seq, file_size: valid_size, idx_mmap: None });
           active_segment_recovered = true;
         } else {
-          // No valid entries at all — remove the segment.
+          // No valid entries at all: remove the segment.
           let _ = compio::fs::remove_file(&log_path).await;
           let _ = compio::fs::remove_file(&idx_path).await;
         }
@@ -464,7 +464,7 @@ impl Inner {
         }
         // The validation scan terminated before EOF on a sealed segment.
         // This can mean a CRC mismatch, an unreadable header, oversized
-        // declared lengths, a truncated tail, or an I/O error — any of
+        // declared lengths, a truncated tail, or an I/O error, any of
         // which is silent data loss: the .log still holds the trailing
         // bytes, but `last_seq` is pinned to the last validated position
         // and reads stop there. Surface this to operators via a metric +
@@ -501,7 +501,7 @@ impl Inner {
       self.cached_last_seq = last.last_seq;
     }
 
-    // Open active segment for appending — only when the last seg_seqs entry
+    // Open active segment for appending, only when the last seg_seqs entry
     // was actually recovered. Otherwise leave active_log = None so the next
     // append creates a fresh segment via Inner::create_segment.
     //
@@ -514,7 +514,7 @@ impl Inner {
       let log_path = self.segment_log_path(seg.first_seq);
       let idx_path = self.segment_idx_path(seg.first_seq);
 
-      // No append mode in compio — use positioned writes at seg.file_size.
+      // No append mode in compio: use positioned writes at seg.file_size.
       let log_file = compio::fs::OpenOptions::new()
         .write(true)
         .open(&log_path)
@@ -565,7 +565,7 @@ impl Inner {
   /// - file exists and its size fits in `(0, idx_capacity]` (oversized `.idx`
   ///   files most often indicate corruption, but can also legitimately appear
   ///   if `segment_max_bytes` or `INDEX_INTERVAL_BYTES` was reduced between
-  ///   runs — rebuilding from the log handles both cases, and bounding the
+  ///   runs; rebuilding from the log handles both cases, and bounding the
   ///   size first also bounds the buffer we load below),
   /// - the size is a multiple of `INDEX_ENTRY_SIZE`,
   /// - the first entry is `(relative_seq=0, offset=0)` (entry-0 rule),
@@ -636,7 +636,7 @@ impl Inner {
   /// the end of the log.
   ///
   /// We mirror that invariant directly by subtracting the offset of the last
-  /// index entry from `valid_size`, instead of scanning the log forward —
+  /// index entry from `valid_size`, instead of scanning the log forward,
   /// which is both faster and avoids an off-by-one bug the scan-based
   /// version had (it skipped the indexed entry's own length, leaving the
   /// next index entry delayed by up to one entry's worth of bytes after
@@ -646,7 +646,7 @@ impl Inner {
       return 0;
     }
     let Ok(idx_data) = compio::fs::read(idx_path).await else {
-      // Index missing or unreadable — conservatively treat the whole valid
+      // Index missing or unreadable: conservatively treat the whole valid
       // range as un-indexed. This seeds `bytes_since_index` from the full
       // validated log size; the normal append/index-interval logic decides
       // when the next index entry is written. In a successful recovery
@@ -676,7 +676,7 @@ impl Inner {
   }
 
   /// List segment base sequences from `.log` filenames.
-  /// Uses `std_fs::read_dir` — no compio equivalent for directory listing.
+  /// Uses `std_fs::read_dir`: no compio equivalent for directory listing.
   fn list_segment_seqs(dir: &Path) -> Vec<u64> {
     let Ok(entries) = std_fs::read_dir(dir) else {
       return Vec::new();
@@ -751,7 +751,7 @@ impl Inner {
   /// (`<first_seq>.tmp`), fsync'd, and then atomically renamed to
   /// `<first_seq>.idx`. A crash mid-rebuild leaves either the previous
   /// `.idx` intact (if the rename hasn't happened yet) or the new one in
-  /// place (if it has) — never a half-written `.idx`. On failure both the
+  /// place (if it has), never a half-written `.idx`. On failure both the
   /// temp file and the existing `.idx` are removed, so the read path falls
   /// back to scanning the segment from the start (`mmap_index` will return
   /// `None`) instead of trusting a stale or partial index.
@@ -879,7 +879,7 @@ impl Inner {
     let log_path = self.segment_log_path(first_seq);
     let idx_path = self.segment_idx_path(first_seq);
 
-    // No append mode in compio — use positioned writes at seg.file_size.
+    // No append mode in compio: use positioned writes at seg.file_size.
     self.active_log =
       Some(compio::fs::OpenOptions::new().create(true).write(true).truncate(true).open(&log_path).await?);
 
@@ -938,7 +938,7 @@ impl Inner {
 
     let retain_from = self.cached_last_seq.saturating_sub(max_messages as u64 - 1);
 
-    // The active (last) segment is never evicted — there must always be a
+    // The active (last) segment is never evicted: there must always be a
     // segment to append into.
     while self.segments.len() > 1 {
       if self.segments[0].last_seq < retain_from {
@@ -1007,8 +1007,8 @@ impl Inner {
   }
 }
 
-// The shard actor model guarantees single-threaded, non-reentrant access —
-// holding a RefCell borrow across .await is safe in this context.
+// The shard actor model guarantees single-threaded, non-reentrant access,
+// so holding a RefCell borrow across .await is safe in this context.
 #[allow(clippy::await_holding_refcell_ref)]
 #[async_trait(?Send)]
 impl MessageLog for FileMessageLog {
@@ -1029,7 +1029,7 @@ impl MessageLog for FileMessageLog {
     // Reject `seq == 0` and non-strictly-monotonic sequences before any state
     // change. `0` is the empty-log sentinel returned by `first_seq`/`last_seq`,
     // so writing an entry with `seq == 0` would persist data while leaving
-    // both cached values at 0 — the log would appear empty afterwards. A
+    // both cached values at 0: the log would appear empty afterwards. A
     // `seq <= cached_last_seq` would corrupt the sparse index, whose binary
     // search assumes strictly monotonic `relative_seq` per segment; a
     // subsequent recovery would mark the index as visibly corrupt and rebuild
@@ -1902,7 +1902,7 @@ mod tests {
       log.flush().await.unwrap();
     }
 
-    // Second session: create a new log from the same directory — should recover.
+    // Second session: create a new log from the same directory; should recover.
     {
       let log = create_log(tmp.path()).await;
 
@@ -2009,7 +2009,7 @@ mod tests {
   #[compio::test]
   async fn test_recovery_increments_metric_on_sealed_segment_corruption() {
     // Regression test: a CRC failure mid-way through a sealed segment is
-    // silent data loss — the bytes past the failure are unreachable but the
+    // silent data loss: the bytes past the failure are unreachable but the
     // file stays on disk. Recovery must surface this as both a metric
     // increment and a tracing warning so disk health can be investigated.
     //
@@ -2071,7 +2071,7 @@ mod tests {
       // Reads of the corrupted segment terminate at the last validated
       // entry, so a sweep over the full range returns fewer entries than
       // were originally appended. The active segment is untouched, so its
-      // entries remain visible — `last_seq()` reports the highest seq, but
+      // entries remain visible: `last_seq()` reports the highest seq, but
       // the *count* visited is short by the entries lost past the
       // corruption boundary.
       let mut visitor = CollectingVisitor::new();
@@ -2087,7 +2087,7 @@ mod tests {
   async fn test_recovery_does_not_promote_sealed_segment_when_active_invalid() {
     // Regression test: if the active (last) segment validates to zero entries,
     // recovery must delete it without "promoting" the previous sealed segment
-    // — otherwise subsequent appends would extend a sealed segment's .log and
+    // otherwise subsequent appends would extend a sealed segment's .log and
     // remap its .idx as MmapMut, corrupting filename-derived first_seq.
     let tmp = tempfile::tempdir().unwrap();
 
@@ -2265,7 +2265,7 @@ mod tests {
 
     // Read starting mid-segment (from_seq > segment's first_seq) so that the
     // read path actually consults the index. Without the rebuild, the bogus
-    // offset lands past EOF and the corrupted segment yields zero entries —
+    // offset lands past EOF and the corrupted segment yields zero entries:
     // visitor.entries[0].seq would be the next segment's first seq instead
     // of 2.
     let mut visitor = CollectingVisitor::new();
@@ -2481,7 +2481,7 @@ mod tests {
     assert_ne!(after, bad_idx, ".idx should have been rebuilt");
 
     // No .tmp files should be left in the channel directory after a
-    // successful rebuild — the rename consumes the temp file.
+    // successful rebuild; the rename consumes the temp file.
     let tmp_files: Vec<_> = std::fs::read_dir(&channel_dir)
       .unwrap()
       .filter_map(|e| e.ok())

--- a/crates/server/src/channel/manager.rs
+++ b/crates/server/src/channel/manager.rs
@@ -1731,7 +1731,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelManager<CS, MLF> {
   ///
   /// When `restore_channels` is `true`, persisted channels are loaded from the
   /// store and restored into the appropriate shards. Pass `false` when auth is
-  /// disabled — without auth, memberships are ephemeral, so restoring them at
+  /// disabled; without auth, memberships are ephemeral, so restoring them at
   /// startup would leave orphaned channels.
   pub async fn bootstrap(&mut self, core_dispatcher: &CoreDispatcher, restore_channels: bool) -> anyhow::Result<()> {
     self.membership.bootstrap(core_dispatcher).await?;

--- a/crates/server/src/channel/store.rs
+++ b/crates/server/src/channel/store.rs
@@ -66,7 +66,7 @@ pub trait MessageLogFactory: Clone + Send + Sync + 'static {
   /// Implementations may perform fallible I/O (e.g. opening the channel
   /// directory, recovering on-disk state, memory-mapping index files). Errors
   /// are returned so the caller can refuse to bring the affected channel
-  /// online — the rest of the server keeps running.
+  /// online; the rest of the server keeps running.
   async fn create(&self, handler: &StringAtom) -> anyhow::Result<Self::Log>;
 }
 

--- a/crates/server/src/util/file.rs
+++ b/crates/server/src/util/file.rs
@@ -36,7 +36,7 @@ pub enum DirSync {
 /// with `EXDEV` and the atomic-write guarantee does not apply.
 ///
 /// When the precondition holds, a crash mid-write leaves either the previous
-/// contents of `path` (if any) or the new contents — never a half-written
+/// contents of `path` (if any) or the new contents, never a half-written
 /// file.
 ///
 /// On error the temp file is removed (best-effort) so a stale `.tmp` doesn't

--- a/crates/server/tests/c2s_channel_persistence.rs
+++ b/crates/server/tests/c2s_channel_persistence.rs
@@ -184,7 +184,7 @@ async fn test_c2s_file_channel_store_deleted_channel_not_restored() -> anyhow::R
     suite.join_channel(TEST_USER_1, CHANNEL, None).await?;
     suite.configure_channel(TEST_USER_1, CHANNEL, None, None, None, Some(true)).await?;
 
-    // Toggle persistence off — should clean up disk storage.
+    // Toggle persistence off: should clean up disk storage.
     suite.configure_channel(TEST_USER_1, CHANNEL, None, None, None, Some(false)).await?;
 
     suite.teardown().await?;
@@ -625,7 +625,7 @@ async fn test_c2s_chan_seq_after_eviction() -> anyhow::Result<()> {
   // max_persist_messages=5 so older messages get evicted.
   suite.configure_channel_full(TEST_USER_1, CHANNEL, None, Some(4096), Some(5), Some(true), Some(0)).await?;
 
-  // Broadcast 20 messages — only the last ~5 should be retained.
+  // Broadcast 20 messages; only the last ~5 should be retained.
   for i in 1..=20 {
     suite.broadcast(TEST_USER_1, CHANNEL, &format!("evict_{i}")).await?;
   }
@@ -749,7 +749,7 @@ async fn test_c2s_history_cross_user() -> anyhow::Result<()> {
   // Drain the MEMBER_JOINED event that user 1 receives.
   suite.ignore_reply(TEST_USER_1).await?;
 
-  // User 1 broadcasts 3 messages (user 2 receives them live — drain those).
+  // User 1 broadcasts 3 messages (user 2 receives them live, drain those).
   for i in 1..=3 {
     suite.broadcast(TEST_USER_1, CHANNEL, &format!("from_u1_{i}")).await?;
     // User 2 receives the live MESSAGE frame.
@@ -947,7 +947,7 @@ async fn test_c2s_history_from_seq_beyond_last() -> anyhow::Result<()> {
     suite.broadcast(TEST_USER_1, CHANNEL, &format!("msg_{i}")).await?;
   }
 
-  // Request history starting from seq 999 — well beyond last_seq.
+  // Request history starting from seq 999, well beyond last_seq.
   suite
     .write_message(
       TEST_USER_1,
@@ -1167,7 +1167,7 @@ async fn test_c2s_toggle_persistence_off_then_on() -> anyhow::Result<()> {
     suite.broadcast(TEST_USER_1, CHANNEL, &format!("old_{i}")).await?;
   }
 
-  // Disable persistence — should clean up the log.
+  // Disable persistence: should clean up the log.
   suite.configure_channel(TEST_USER_1, CHANNEL, None, None, None, Some(false)).await?;
 
   // Re-enable persistence and broadcast new messages.

--- a/crates/server/tests/c2s_modulator_tests.rs
+++ b/crates/server/tests/c2s_modulator_tests.rs
@@ -1097,7 +1097,7 @@ async fn test_c2s_persisted_channels_restored_when_auth_enabled() -> anyhow::Res
   let store = InMemoryChannelStore::new();
   seed_persistent_channel(&store, "!persist@localhost").await?;
 
-  // Restart with auth enabled — channel should be restored.
+  // Restart with auth enabled: channel should be restored.
   let modulator = TestModulator::new()
     .with_auth_handler(|token| async move { Ok(AuthResult::Success { username: StringAtom::from(token.as_ref()) }) });
 
@@ -1157,7 +1157,7 @@ async fn test_c2s_persisted_channels_not_restored_when_auth_disabled() -> anyhow
   let store = InMemoryChannelStore::new();
   seed_persistent_channel(&store, "!persist@localhost").await?;
 
-  // Restart WITHOUT auth (no modulator) — channel should NOT be restored.
+  // Restart WITHOUT auth (no modulator): channel should NOT be restored.
   let mlf = narwhal_server::channel::NoopMessageLogFactory;
   let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), None, None, store.clone(), mlf).await?;
   suite.setup().await?;

--- a/crates/server/tests/c2s_tests.rs
+++ b/crates/server/tests/c2s_tests.rs
@@ -503,7 +503,7 @@ async fn test_c2s_leave_on_behalf() -> anyhow::Result<()> {
   suite.join_channel(TEST_USER_1, "!test1@localhost", None).await?;
   suite.join_channel(TEST_USER_2, "!test1@localhost", None).await?;
 
-  // Ignore new member EVENT message...
+  // Ignore new member EVENT message.
   suite.ignore_reply(TEST_USER_1).await?;
 
   // Leave on behalf of another user (test_user_2@localhost).
@@ -555,7 +555,7 @@ async fn test_c2s_leave_as_owner() -> anyhow::Result<()> {
   suite.join_channel(TEST_USER_1, "!test1@localhost", None).await?;
   suite.join_channel(TEST_USER_1, "!test1@localhost", Some("test_user_2@localhost")).await?;
 
-  // Ignore new member EVENT message...
+  // Ignore new member EVENT message.
   suite.ignore_reply(TEST_USER_2).await?;
 
   // Leave from the channel as owner.
@@ -640,7 +640,7 @@ async fn test_c2s_list_members() -> anyhow::Result<()> {
   suite.join_channel(TEST_USER_2, "!test1@localhost", None).await?;
   suite.join_channel(TEST_USER_3, "!test1@localhost", None).await?;
 
-  // Ignore new member EVENT messages...
+  // Ignore new member EVENT messages.
   suite.ignore_reply(TEST_USER_1).await?;
   suite.ignore_reply(TEST_USER_1).await?;
 
@@ -1350,7 +1350,7 @@ async fn test_c2s_channel_acl() -> anyhow::Result<()> {
   suite.join_channel(TEST_USER_1, "!test1@localhost", None).await?;
   suite.join_channel(TEST_USER_2, "!test1@localhost", None).await?;
 
-  // Ignore new member EVENT message...
+  // Ignore new member EVENT message.
   suite.ignore_reply(TEST_USER_1).await?;
 
   // Set the channel ACL for join permissions
@@ -1772,11 +1772,11 @@ async fn test_c2s_broadcast() -> anyhow::Result<()> {
 
   suite.join_channel(TEST_USER_1, "!test1@localhost", Some("test_user_3@localhost")).await?;
 
-  // Ignore new member EVENT messages...
+  // Ignore new member EVENT messages.
   suite.ignore_reply(TEST_USER_2).await?;
   suite.ignore_reply(TEST_USER_3).await?;
 
-  // Broadcast a message to the channel...
+  // Broadcast a message to the channel.
   suite.broadcast(TEST_USER_1, "!test1@localhost", "Hello world!").await?;
 
   // Verify that the server sent the proper message to the other users.
@@ -1824,7 +1824,7 @@ async fn test_c2s_broadcast_invalid_payload() -> anyhow::Result<()> {
   // Create a channel.
   suite.join_channel(TEST_USER_1, "!test1@localhost", None).await?;
 
-  // Broadcast a message to the channel...
+  // Broadcast a message to the channel.
   suite
     .write_message(
       TEST_USER_1,
@@ -1837,7 +1837,7 @@ async fn test_c2s_broadcast_invalid_payload() -> anyhow::Result<()> {
     )
     .await?;
 
-  // ... along with an invalid payload.
+  // Then send an invalid payload.
   suite.write_raw_bytes(TEST_USER_1, b"AAAA\n").await?;
 
   // Verify that the server sent the proper error message.
@@ -1884,7 +1884,7 @@ async fn test_c2s_channel_acl_publish_deny() -> anyhow::Result<()> {
     )
     .await?;
 
-  // Broadcast a message to the channel...
+  // Broadcast a message to the channel.
   suite
     .write_message(
       TEST_USER_2,
@@ -1947,7 +1947,7 @@ async fn test_c2s_channel_acl_read_deny() -> anyhow::Result<()> {
     )
     .await?;
 
-  // Broadcast a message to the channel...
+  // Broadcast a message to the channel.
   suite.broadcast(TEST_USER_1, "!test1@localhost", "Hello world!").await?;
 
   // Verify that the server sent the proper message to the other users.
@@ -2166,10 +2166,10 @@ async fn test_c2s_max_channels_reached() -> anyhow::Result<()> {
 
   suite.identify(TEST_USER_1).await?;
 
-  // Create the first channel — should succeed.
+  // Create the first channel: should succeed.
   suite.join_channel(TEST_USER_1, "!test1@localhost", None).await?;
 
-  // Try to create a second channel — should fail with ResourceLimitReached.
+  // Try to create a second channel: should fail with ResourceLimitReached.
   suite
     .write_message(
       TEST_USER_1,
@@ -2188,7 +2188,7 @@ async fn test_c2s_max_channels_reached() -> anyhow::Result<()> {
     }
   );
 
-  // Verify the client is still connected — send a valid request.
+  // Verify the client is still connected by sending a valid request.
   suite.leave_channel(TEST_USER_1, "!test1@localhost").await?;
 
   suite.teardown().await?;

--- a/crates/test-util/src/c2s_suite.rs
+++ b/crates/test-util/src/c2s_suite.rs
@@ -410,7 +410,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> C2sSuite<CS, MLF> {
       )
       .await?;
 
-    // ... along with the payload.
+    // along with the payload.
     self.write_raw_bytes(username, payload.as_bytes()).await?;
     self.write_raw_bytes(username, b"\n").await?;
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -110,9 +110,9 @@ Narwhal implements a custom TCP-based protocol rather than leveraging existing p
 
 2. **Simplicity Through Constraint**: The protocol intentionally avoids complex features like nested types or recursive data structures. Message parameters are flat, consisting of simple scalar values (strings, integers) with optional binary payloads. This constraint makes the protocol easier to implement, debug, and reason about, while still providing all the functionality needed for pub/sub messaging.
 
-3. **Efficiency Without Complexity**: By avoiding nested types and keeping message structures flat, we eliminate the need for complex parsing and serialization logic. This reduces CPU overhead, memory allocations, and latency—critical factors for real-time systems handling thousands of concurrent connections.
+3. **Efficiency Without Complexity**: By avoiding nested types and keeping message structures flat, we eliminate the need for complex parsing and serialization logic. This reduces CPU overhead, memory allocations, and latency, which are critical factors for real-time systems handling thousands of concurrent connections.
 
-4. **Hybrid Design for Future Flexibility**: The protocol uses a hybrid approach with text-based message headers and binary payloads. This provides excellent debuggability during development (text headers are human-readable over the wire) while maintaining efficiency for payload delivery. Importantly, this design can be trivially migrated to a fully binary protocol if needed—the text headers can be replaced with binary-encoded message types and length-prefixed parameters without changing the protocol's semantics.
+4. **Hybrid Design for Future Flexibility**: The protocol uses a hybrid approach with text-based message headers and binary payloads. This provides excellent debuggability during development (text headers are human-readable over the wire) while maintaining efficiency for payload delivery. Importantly, this design can be trivially migrated to a fully binary protocol if needed: the text headers can be replaced with binary-encoded message types and length-prefixed parameters without changing the protocol's semantics.
 
 5. **Tailored Message Flow**: Generic protocols often impose constraints that don't align with our needs. For example, HTTP's request-response model doesn't naturally support bidirectional streaming or server-initiated messages. By building our own protocol, we can design message flows that perfectly match the pub/sub domain: connection handshakes, channel subscriptions, broadcasts, and modulator delegation.
 
@@ -518,7 +518,7 @@ Acknowledges a channel leave request.
 LEAVE_ACK id=2
 ```
 
-**Disconnect behavior**: When a user's last connection disconnects, the server automatically removes them from all **transient** (non-persistent) channels. Membership in **persistent** channels (`persist=true`) is preserved across disconnects — users remain members until they explicitly leave or are removed by the channel owner. Without authentication, all channel memberships are always cleaned up on disconnect regardless of the persistence flag.
+**Disconnect behavior**: When a user's last connection disconnects, the server automatically removes them from all **transient** (non-persistent) channels. Membership in **persistent** channels (`persist=true`) is preserved across disconnects; users remain members until they explicitly leave or are removed by the channel owner. Without authentication, all channel memberships are always cleaned up on disconnect regardless of the persistence flag.
 
 ---
 
@@ -894,7 +894,7 @@ CHAN_CONFIG id=9 channel=!42@example.com max_clients=100 max_payload_size=104857
 
 ### SET_CHAN_CONFIG
 
-Sets the configuration for a channel. Only the channel owner can modify configuration. All configuration parameters are optional — only the fields present in the message are updated; absent fields retain their current values.
+Sets the configuration for a channel. Only the channel owner can modify configuration. All configuration parameters are optional: only the fields present in the message are updated; absent fields retain their current values.
 
 **Direction**: Client → Server
 
@@ -1467,7 +1467,7 @@ Server → Other Clients: MESSAGE channel=!42@example.com from=alice@example.com
 Server → Other Clients: [payload: "Hello, World!"]
 ```
 
-The `seq` in `BROADCAST_ACK` matches the `seq` in the `MESSAGE` delivered to recipients — both refer to the same position in the channel's message log. The `timestamp` is assigned once by the server and is identical for all recipients of the same broadcast.
+The `seq` in `BROADCAST_ACK` matches the `seq` in the `MESSAGE` delivered to recipients; both refer to the same position in the channel's message log. The `timestamp` is assigned once by the server and is identical for all recipients of the same broadcast.
 
 ### Example 3a: Authentication with Modulator Support
 

--- a/docs/architecture/ACTOR_SHARDING.md
+++ b/docs/architecture/ACTOR_SHARDING.md
@@ -1,4 +1,4 @@
-# Actor-Based Sharding — Architecture Specification
+# Actor-Based Sharding: Architecture Specification
 
 > **Status:** Implemented.
 
@@ -36,8 +36,8 @@
 Narwhal runs N OS threads, each pinned to a CPU core and hosting a
 [compio](https://github.com/compio-rs/compio) runtime (accessed through the
 `narwhal_common::runtime` shim). A small set of stateful
-subsystems — the C2S connection router, the channel manager, and the
-per-user membership tracker — shard their state across those threads. Each
+subsystems (the C2S connection router, the channel manager, and the
+per-user membership tracker) shard their state across those threads. Each
 shard is an **actor**: it owns a partition of the subsystem's data, receives
 `Command` messages through a bounded mailbox, and processes them one at a
 time on its home thread.
@@ -80,7 +80,7 @@ same four pieces:
 
 Each subsystem chooses a **sharding key**, hashes it, and routes the command to the owning shard. The shard
 holds an ordinary `HashMap<Key, State>` and mutates it with plain `&mut self`
-— no locks, no atomics on the state itself, because every command for a given
+with no locks, no atomics on the state itself, because every command for a given
 key is serialized through a single thread.
 
 ## Goals and Non-Goals
@@ -108,14 +108,14 @@ key is serialized through a single thread.
 ## CoreDispatcher
 
 `CoreDispatcher` is the shared worker pool that every sharded subsystem
-builds on top of. It knows nothing about actors, commands, or mailboxes — it
+builds on top of. It knows nothing about actors, commands, or mailboxes; it
 just accepts closures and runs them on a specific worker.
 
 ### Thread Model
 
 | Property | Value |
 |----------|-------|
-| Thread count | `num_workers()` — `NARWHAL_NUM_WORKERS` env var, or `available_parallelism()` |
+| Thread count | `num_workers()`: `NARWHAL_NUM_WORKERS` env var, or `available_parallelism()` |
 | Thread name | `core-worker-{id}` |
 | Runtime per thread | compio (via `narwhal_common::runtime::try_block_on`) |
 | CPU affinity | `core_affinity::set_for_current(core_ids[id % cores.len()])`, best-effort |
@@ -202,7 +202,7 @@ Two things to note:
 - The closure `f` is `Send + 'static` but the **future it returns** is only
   `'static`. That means `f` runs on the worker thread, constructs the
   future there, and hands it to `spawn_detached`. The future itself never
-  crosses a thread boundary, so it does not need to be `Send` — compio's
+  crosses a thread boundary, so it does not need to be `Send`. Compio's
   per-worker runtime is single-threaded and its tasks are spawned locally.
 - `dispatch_at_shard` itself does not await the future's completion. It only
   awaits enqueueing the closure on the worker's drainer task. Subsystems that
@@ -232,7 +232,7 @@ channel only terminates the drainer task, not the runtime itself. The
 
 Every sharded subsystem in narwhal is a variation on the following shape.
 Rather than abstract it into a framework, the same ~50 lines are written
-out three times (router, channel manager, membership) — each with its own
+out three times (router, channel manager, membership), each with its own
 `Command` enum, shard struct, and sharding key. The pattern is simple enough
 that explicit code reads better than a generic trait tower.
 
@@ -249,13 +249,13 @@ fn shard_for(key: &StringAtom, shard_count: usize) -> usize {
 | Property | Value |
 |----------|-------|
 | Hasher | `std::hash::DefaultHasher` (SipHash-1-3 today) |
-| Seed | Fresh per call — **stateless**, so every caller agrees on the shard for a given key |
+| Seed | Fresh per call: **stateless**, so every caller agrees on the shard for a given key |
 | Distribution | Uniform in expectation; no rebalancing |
 | Sharing | Defined independently in each subsystem; not a shared utility |
 
 Using `DefaultHasher` (rather than a faster non-cryptographic hash) gives
-resistance to accidentally-adversarial input — e.g. a client spamming
-similar usernames — at the cost of a few nanoseconds per dispatch.
+resistance to accidentally-adversarial input (e.g. a client spamming
+similar usernames) at the cost of a few nanoseconds per dispatch.
 
 ### Mailboxes and Commands
 
@@ -277,7 +277,7 @@ pub struct Subsystem {
 |----------|-------|
 | Channel type | `async_channel::bounded` (MPSC in practice, MPMC by type) |
 | Capacity | `DEFAULT_MAILBOX_CAPACITY = 16384` per shard |
-| Storage | `Arc<[Sender<Command>]>` — fixed-size after bootstrap, cheap to clone |
+| Storage | `Arc<[Sender<Command>]>`: fixed-size after bootstrap, cheap to clone |
 | Backpressure | `mailboxes[shard].send(cmd).await` parks the caller when the shard is full |
 
 The `Arc<[Sender<Command>]>` is rebuilt from a `Vec` at the end of
@@ -311,7 +311,7 @@ let _ = reply_tx.send(result).await;
 
 `async_channel::bounded(1)` is used rather than `oneshot` because the rest of
 the code already depends on `async_channel` and the one-message restriction
-is enforced by convention — every call site sends at most once. Fire-and-
+is enforced by convention: every call site sends at most once. Fire-and-
 forget commands (e.g. `Router::RouteTo`) simply omit `reply_tx`.
 
 ### Shard Actor Loop
@@ -392,7 +392,7 @@ to every connection handler, dispatcher factory, and background task:
 
 | Field | Clone cost |
 |-------|------------|
-| `mailboxes: Arc<[Sender<Command>]>` | `Arc::clone` — one atomic increment, all clones share senders |
+| `mailboxes: Arc<[Sender<Command>]>` | `Arc::clone`: one atomic increment, all clones share senders |
 | `Arc<AtomicUsize>` counters | `Arc::clone` |
 | `mailbox_capacity: usize` | `Copy` |
 | Other `Arc<_>` handles | `Arc::clone` |
@@ -424,7 +424,7 @@ if `exclusive: true` and the user already has connections, the shard
 returns `false` without mutating state.
 
 `Unregister`'s `bool` reply means "this was the last connection for the
-user" — useful to the caller for cleanup sequencing. The shard's
+user", useful to the caller for cleanup sequencing. The shard's
 per-username `Vec<Entry>` can hold multiple connections (e.g. multi-device
 sessions); only emptying it counts.
 
@@ -436,14 +436,14 @@ commands, drive message-log appends.
 | Aspect | Value |
 |--------|-------|
 | Sharding key | `channel handler` (`StringAtom`) |
-| Shard state | `HashMap<StringAtom, Channel<MLF::Log>>` — the full per-channel in-memory state (owner, ACL, members, message log, flush task) |
+| Shard state | `HashMap<StringAtom, Channel<MLF::Log>>`: the full per-channel in-memory state (owner, ACL, members, message log, flush task) |
 | Commands | `JoinChannel`, `LeaveChannel`, `LeaveChannels`, `DeleteChannel`, `BroadcastPayload`, config/ACL ops, `History`, `ChannelSeq` |
 | Extra shared state | `Arc<AtomicUsize>` total-channels counter; `Membership` handle (separately sharded) |
 | Factories | `ChannelStore` (metadata persistence) + `MessageLogFactory` (log persistence), both `Clone`-d into each shard |
 
 Every reply-bearing command returns `anyhow::Result<T>` so business-logic
-errors (`ChannelNotFound`, `Forbidden`, `PolicyViolation`, …) flow back to
-the caller on the reply channel. Shard actors never panic on bad input —
+errors (`ChannelNotFound`, `Forbidden`, `PolicyViolation`, etc.) flow back to
+the caller on the reply channel. Shard actors never panic on bad input;
 they serialize the error into `reply_tx` and keep looping.
 
 `ChannelShard::restore_and_run(hashes)` wraps the standard loop with a
@@ -461,13 +461,13 @@ disconnect cleanup.
 | Aspect | Value |
 |--------|-------|
 | Sharding key | `username` (`StringAtom`) |
-| Shard state | `HashMap<StringAtom, HashSet<StringAtom>>` — user → set of channel handlers |
+| Shard state | `HashMap<StringAtom, HashSet<StringAtom>>`: user → set of channel handlers |
 | Commands | `ReserveSlot` (→ `bool`), `ReleaseSlot`, `GetChannels` (→ `Arc<[StringAtom]>`) |
 | Callers | Channel shards (from `join_channel` / `do_leave`) and connection cleanup paths |
 
 `Membership` exists because `ChannelManager` is sharded by **channel**, not
 by user. A client that subscribes to channels across multiple shards leaves
-no single `ChannelShard` with a complete view of its subscriptions — so the
+no single `ChannelShard` with a complete view of its subscriptions, so the
 per-client subscription count can't be enforced inside a channel shard, and
 "find every channel a user is in" would require an all-shard fan-out.
 
@@ -541,7 +541,7 @@ Rationale:
 ## Concurrency Model
 
 - Each shard actor runs on exactly one worker thread. All state it owns is
-  accessed only from that thread — `HashMap<Key, State>` with `&mut self`.
+  accessed only from that thread: `HashMap<Key, State>` with `&mut self`.
 - Shared state across shards is `Arc`-wrapped and carefully chosen:
   `AtomicUsize` for counters, another sharded actor (`Membership`) for
   user-indexed queries. There is no shared `Mutex`/`RwLock` on the hot path.
@@ -551,8 +551,8 @@ Rationale:
 - `async_channel` is MPMC, but each mailbox has exactly one consumer (its
   shard actor). The multi-sender side is what every caller uses.
 - `dispatch_at_shard` ensures the shard actor is spawned on the correct
-  worker. Its type signature — `F: FnOnce() -> Fut + Send + 'static` with
-  `Fut: Future + 'static` (no `Send` bound on the future) — means the
+  worker. Its type signature, `F: FnOnce() -> Fut + Send + 'static` with
+  `Fut: Future + 'static` (no `Send` bound on the future), means the
   closure is shipped to the worker, but the future it returns is
   constructed and spawned there. The actor's state never crosses a thread
   boundary.
@@ -568,7 +568,7 @@ Rationale:
 | Shutdown channel per worker | 1 | `async_channel::bounded::<()>(1)` |
 
 `DEFAULT_MAILBOX_CAPACITY` is duplicated in each subsystem (router, channel
-manager, membership) — a deliberate choice so each subsystem can be tuned
+manager, membership): a deliberate choice so each subsystem can be tuned
 independently if traffic patterns diverge.
 
 ## Dependencies
@@ -598,8 +598,8 @@ independently if traffic patterns diverge.
 
 | File | Purpose |
 |------|---------|
-| `crates/common/src/core_dispatcher.rs` | `CoreDispatcher` — thread pool + compio runtimes |
-| `crates/common/src/runtime.rs` | `try_block_on`, `spawn_detached` — compio runtime shims |
+| `crates/common/src/core_dispatcher.rs` | `CoreDispatcher`: thread pool + compio runtimes |
+| `crates/common/src/runtime.rs` | `try_block_on`, `spawn_detached`: compio runtime shims |
 | `crates/server/src/c2s/router.rs` | `Router` + `RouterShard` (sharded by username) |
 | `crates/server/src/channel/manager.rs` | `ChannelManager` + `ChannelShard` (sharded by channel) |
 | `crates/server/src/channel/membership.rs` | `Membership` + `MembershipShard` (sharded by username) |

--- a/docs/architecture/CHANNEL_STORE.md
+++ b/docs/architecture/CHANNEL_STORE.md
@@ -1,4 +1,4 @@
-# Channel Store — Architecture Specification
+# Channel Store: Architecture Specification
 
 > **Status:** Implemented.
 > **Related PRs:** see `crates/server/src/channel/file_store.rs` history.
@@ -33,7 +33,7 @@
 
 ## Overview
 
-The channel store is the persistence layer for **channel metadata** — the
+The channel store is the persistence layer for **channel metadata**: the
 handler, owner, configuration, ACLs, and sorted member list of each persistent
 channel. It is separate from, but colocated with, the
 [message log](MESSAGE_LOG.md) that persists broadcast messages.
@@ -76,14 +76,14 @@ hashing the handler modulo the shard count).
   ACLs, member list).
 - Survive process restart: rebuild the full membership graph and resume
   broadcasts at the correct sequence number.
-- Atomic updates — a concurrent crash must leave either the old or the new
+- Atomic updates: a concurrent crash must leave either the old or the new
   version intact, never a half-written file.
 - Share a single on-disk directory with the message log so that deleting a
   channel is a single-directory operation.
 
 **Non-Goals:**
 - Cross-channel queries (there is no global index beyond directory enumeration).
-- Incremental metadata updates — each save rewrites the whole file.
+- Incremental metadata updates; each save rewrites the whole file.
 - Version migration tooling (the current format has no version byte; see
   [Constants](#constants)).
 - Replication or distributed consensus.
@@ -126,7 +126,7 @@ fn channel_hash(handler: &StringAtom) -> StringAtom {
 |----------|-------|
 | Algorithm | SHA-256 |
 | Encoding  | Lowercase hex, 64 characters |
-| Inputs    | `handler.as_bytes()` — no salt, no normalization |
+| Inputs    | `handler.as_bytes()`; no salt, no normalization |
 | Determinism | Same handler ⇒ same hash forever |
 
 Using a hash (instead of the raw handler) gives a fixed-length, filesystem-safe
@@ -161,9 +161,9 @@ pub struct PersistedChannel {
 | Property | Value |
 |----------|-------|
 | Encoding | postcard (varint-length-prefixed, little-endian) |
-| Header | None — the format has no magic bytes or version byte |
-| Integrity | No CRC — atomic write protocol avoids torn writes, but does not provide corruption detection (see below) |
-| Max size | 64 MiB — enforced on load to refuse obviously corrupt files |
+| Header | None; the format has no magic bytes or version byte |
+| Integrity | No CRC; atomic write protocol avoids torn writes, but does not provide corruption detection (see below) |
+| Max size | 64 MiB; enforced on load to refuse obviously corrupt files |
 
 **Why no CRC:** the atomic write protocol (write-tmp → fsync → rename → fsync
 parent dir) guarantees that readers always see either the previous successful
@@ -208,7 +208,7 @@ pub trait ChannelStore: Clone + Send + Sync + 'static {
 ```
 
 **Key design decisions:**
-- `save_channel` accepts a *projected* `PersistedChannel` — callers build the
+- `save_channel` accepts a *projected* `PersistedChannel`; callers build the
   post-change snapshot, and the store rewrites the file whole. No partial
   updates.
 - `save_channel` returns the storage hash so the caller can cache it on the
@@ -224,7 +224,7 @@ pub trait ChannelStore: Clone + Send + Sync + 'static {
 ### PersistedChannel
 
 The persisted struct mirrors the in-memory `Channel` but only the fields that
-must survive a restart — ephemeral state (subscribers, broadcast sequence
+must survive a restart. Ephemeral state (subscribers, broadcast sequence
 counter, flush tasks) is reconstructed on restore.
 
 | Field | Reconstructed on restore? |
@@ -262,10 +262,10 @@ save_channel(projected)
 
 Steps 5 and 7 are what make the write crash-safe:
 
-| Step | If the process crashes immediately after… | Result after restart |
+| Step | If the process crashes immediately after | Result after restart |
 |------|-------------------------------------------|----------------------|
 | 4 | tmp file written but not fsynced | `metadata.bin.tmp` may be zero-length or partial; ignored (only `metadata.bin` is loaded) |
-| 5 | tmp contents are durable | Ditto — `metadata.bin.tmp` ignored |
+| 5 | tmp contents are durable | Ditto; `metadata.bin.tmp` ignored |
 | 6 | rename durable in directory cache but parent not fsynced | On most filesystems the rename may not have reached disk; the *previous* `metadata.bin` remains visible |
 | 7 | parent dir fsynced | New `metadata.bin` is guaranteed visible post-crash |
 
@@ -306,7 +306,7 @@ delete_channel(hash)
 ```
 
 Step 3 succeeds only if the directory is empty. If the channel still has
-message log segments, `remove_dir` fails — which is the intended behavior:
+message log segments, `remove_dir` fails, which is the intended behavior:
 the caller (`ChannelShard::delete_persistent_storage`) always calls
 `message_log.delete()` first, so log files are gone by the time
 `delete_channel` runs. If the log delete fails, the metadata delete will
@@ -343,7 +343,7 @@ load_channel_hashes()
 └─ Return Arc<[StringAtom]>
 ```
 
-A directory **without** a `metadata.bin` is by definition not a live channel —
+A directory **without** a `metadata.bin` is by definition not a live channel:
 either a crashed-at-creation leftover or a residue of a failed delete. The
 sweep keeps the data directory tidy so repeated crashes don't accumulate
 garbage.
@@ -370,10 +370,10 @@ bootstrap(core_dispatcher, restore_channels):
 This pre-load uses two round trips per channel (`load_channel_hashes` then
 `load_channel`) but runs only once, on the coordinating thread, before any
 shard starts. The hashes (not the full metadata) are what get dispatched to
-shards — each shard re-loads its assigned channels on its own thread during
+shards. Each shard re-loads its assigned channels on its own thread during
 `restore_and_run`. This keeps `PersistedChannel`'s `Rc<[Nid]>` thread-local.
 
-`restore_channels` is `false` when auth is disabled — without authentication,
+`restore_channels` is `false` when auth is disabled. Without authentication,
 memberships are session-scoped and have no meaning across restarts, so
 restoring them would produce orphaned channels.
 
@@ -403,7 +403,7 @@ For each hash:
 
 **Guarantees:**
 - A channel whose `metadata.bin` fails to load is **skipped** (with a warning),
-  not fatal — one corrupt channel cannot prevent the server from starting.
+  not fatal; one corrupt channel cannot prevent the server from starting.
 - Broadcast sequence numbers are continuous across restarts: every new
   broadcast has `seq > last_seq` of whatever survived in the message log.
 - Per-client channel limits are only enforced on *new* joins, never on
@@ -422,7 +422,7 @@ share a directory by convention:
 | Update frequency | Rare (join/leave/config/ACL) | Every broadcast |
 | Directory derivation | `sha256_hex(handler)` | `sha256_hex(handler)` (same function) |
 
-The shared hashing function is the only coupling between the two — everything
+The shared hashing function is the only coupling between the two; everything
 else (file naming, I/O model, recovery) is independent. `FileMessageLog`
 never reads `metadata.bin`, and `FileChannelStore` never reads log segments.
 
@@ -438,12 +438,12 @@ next start.
   single-threaded on the owning shard's thread.
 - `FileChannelStore` is `Clone + Send + Sync`: cloned into each shard at
   bootstrap, each shard uses its own copy.
-- Internal state is just `Arc<PathBuf>` — no mutability, no locks, no atomics.
+- Internal state is just `Arc<PathBuf>`: no mutability, no locks, no atomics.
 - Two shards can save different channels concurrently (different directories),
   but never the **same** channel, because each channel is pinned to exactly
   one shard.
 - Within a shard, `save_channel` calls are naturally serialized by the
-  single-threaded actor loop; there is no in-flight-save coalescing — each
+  single-threaded actor loop; there is no in-flight-save coalescing; each
   mutation triggers one save.
 
 ## Constants

--- a/docs/architecture/CHANNEL_STORE.md
+++ b/docs/architecture/CHANNEL_STORE.md
@@ -262,7 +262,7 @@ save_channel(projected)
 
 Steps 5 and 7 are what make the write crash-safe:
 
-| Step | If the process crashes immediately after | Result after restart |
+| Step | If the process crashes immediately after this step | Result after restart |
 |------|-------------------------------------------|----------------------|
 | 4 | tmp file written but not fsynced | `metadata.bin.tmp` may be zero-length or partial; ignored (only `metadata.bin` is loaded) |
 | 5 | tmp contents are durable | Ditto; `metadata.bin.tmp` ignored |

--- a/docs/architecture/FIFO_CHANNELS.md
+++ b/docs/architecture/FIFO_CHANNELS.md
@@ -42,7 +42,7 @@ A **FIFO channel** is a work-queue style channel where:
 
 - The channel **owner** is the only client that can publish elements (via `PUSH`).
 - Any **JOINed, read-authorized member** can consume elements (via `POP`).
-  The existing read ACL applies, the same gate used for `MESSAGE` delivery
+  The existing read ACL applies; it is the same gate used for `MESSAGE` delivery
   on pub/sub channels.
 - Each element is **returned by at most one successful `POP`**
   (competing-consumers model). Under the at-most-once loss model an element

--- a/docs/architecture/FIFO_CHANNELS.md
+++ b/docs/architecture/FIFO_CHANNELS.md
@@ -1,4 +1,4 @@
-# FIFO Channels — Architecture Specification
+# FIFO Channels: Architecture Specification
 
 > **Status:** Proposed. Not yet implemented.
 > **Related design:** [Message Log](MESSAGE_LOG.md), [Channel Store](CHANNEL_STORE.md)
@@ -16,7 +16,7 @@
   - [Living as a FIFO Channel](#living-as-a-fifo-channel)
   - [Destroying a FIFO Channel](#destroying-a-fifo-channel)
 - [Protocol Additions](#protocol-additions)
-  - [Configuration messages — `type` field](#configuration-messages--type-field)
+  - [Configuration messages: `type` field](#configuration-messages-type-field)
   - [`PUSH` / `PUSH_ACK`](#push--push_ack)
   - [`POP` / `POP_ACK`](#pop--pop_ack)
   - [`GET_CHAN_LEN` / `CHAN_LEN`](#get_chan_len--chan_len)
@@ -42,12 +42,12 @@ A **FIFO channel** is a work-queue style channel where:
 
 - The channel **owner** is the only client that can publish elements (via `PUSH`).
 - Any **JOINed, read-authorized member** can consume elements (via `POP`).
-  The existing read ACL applies — the same gate used for `MESSAGE` delivery
+  The existing read ACL applies, the same gate used for `MESSAGE` delivery
   on pub/sub channels.
 - Each element is **returned by at most one successful `POP`**
   (competing-consumers model). Under the at-most-once loss model an element
   may be returned by zero successful `POP`s if the server crashes between
-  cursor fsync and `POP_ACK` socket write — see
+  cursor fsync and `POP_ACK` socket write; see
   [Cursor Durability](#cursor-durability).
 - Consumption is **destructive**: once `POP` returns an element, it is gone from the queue.
 
@@ -86,7 +86,7 @@ be transitioned to FIFO once, but the reverse is not allowed.
 FIFO channels implement **competing consumers**: when N JOINed clients are issuing
 `POP`s concurrently against the same FIFO channel, each element is returned by
 **at most one** successful `POP` (zero if the server crashes between cursor fsync
-and `POP_ACK` socket write — see the [loss model](#loss-model)). Two clients
+and `POP_ACK` socket write; see the [loss model](#loss-model)). Two clients
 calling `POP` simultaneously will receive different elements (or one of them will
 receive `QUEUE_EMPTY`); they will never both receive the same element.
 
@@ -98,7 +98,7 @@ cursor. There is no fairness scheduler beyond mailbox arrival order
 ### Ordering and Concurrency
 
 `PUSH` and `POP` are both processed on the channel's shard actor (existing
-sharding by channel handler — see [ACTOR_SHARDING.md](ACTOR_SHARDING.md)).
+sharding by channel handler, see [ACTOR_SHARDING.md](ACTOR_SHARDING.md)).
 This serialization gives:
 
 - `PUSH`es from the owner are appended to the log in arrival order.
@@ -107,7 +107,7 @@ This serialization gives:
   (`Channel::next_seq()` in `crates/server/src/channel/manager.rs`) before
   the entry is appended; the message log persists whatever `seq` it is
   given. This matches the pub/sub `BROADCAST` path. **`seq` is not exposed
-  on the wire** for FIFO commands — it is an internal invariant only.
+  on the wire** for FIFO commands; it is an internal invariant only.
 
 ### Loss Model
 
@@ -129,7 +129,7 @@ There is **no** `CREATE` command. A FIFO channel is born from an ordinary
 pub/sub channel via reconfiguration:
 
 1. A client `JOIN`s a non-existent channel name. The channel is auto-created as
-   pub/sub. The first joiner becomes the owner (existing behavior — see
+   pub/sub. The first joiner becomes the owner (existing behavior; see
    `Channel.owner`, `crates/server/src/channel/manager.rs`).
 2. The owner sends `SET_CHAN_CONFIG id=<corr> channel=<name> type=fifo
    persist=true max_persist_messages=<N>` to convert the channel.
@@ -140,7 +140,7 @@ pub/sub channel via reconfiguration:
 unless the merged-config result satisfies all of:
 
 - `type = fifo`
-- `persist = true` (FIFO channels are inherently persistent — the head cursor
+- `persist = true` (FIFO channels are inherently persistent: the head cursor
   and segment files must survive restart).
 - `max_persist_messages > 0` (the queue depth cap; without it, `QUEUE_FULL`
   cannot be enforced).
@@ -151,21 +151,21 @@ Existing pub/sub state at transition time:
   consumers eligible to `POP`.
 - **Buffered messages are purged logically (no physical truncation).** Any
   messages held in the message log at transition time become unreachable to
-  consumers — they belong to the pub/sub semantics and have already been
+  consumers; they belong to the pub/sub semantics and have already been
   delivered (or evicted) under those rules. Head-eviction reclaims the
   now-unreachable segments lazily as the cursor stays past them, modulo
   the [tail-segment retention invariant](#segment-eviction) which keeps
   `log.last_seq()` recoverable.
 
 - **Crash-safe transition ordering.** The transition durably touches two
-  artifacts: `cursor.bin` (new — initial head) and `metadata.bin`
-  (updated — `channel_type=fifo`, possibly `persist`/`max_persist_messages`).
+  artifacts: `cursor.bin` (new: initial head) and `metadata.bin`
+  (updated: `channel_type=fifo`, possibly `persist`/`max_persist_messages`).
   Order: **flush log → write cursor → write metadata**.
 
   1. **Establish the durable log tail.** Synchronously flush the message
      log and fsync, so `log.last_seq()` reflects on-disk state and is not
      just an in-memory value. (`MessageLog::last_seq()` can otherwise
-     include unflushed appends — initializing the cursor from a
+     include unflushed appends; initializing the cursor from a
      non-durable tail risks `cursor.next_seq > log.last_seq() + 1` after
      a crash, which the recovery model treats as corruption.)
   2. Atomic write of `cursor.bin` with `next_seq = log.last_seq() + 1`
@@ -178,7 +178,7 @@ Existing pub/sub state at transition time:
 
   - **Crash before (2)** (during or after the log flush, before the
     cursor write): no FIFO state has been committed. On restart the
-    channel restores from whatever `metadata.bin` exists (or doesn't —
+    channel restores from whatever `metadata.bin` exists (or doesn't;
     see below). The transition simply did not happen; the operator
     retries `SET_CHAN_CONFIG`.
   - **Crash between (2) and (3)** has two sub-cases depending on whether
@@ -190,7 +190,7 @@ Existing pub/sub state at transition time:
       reads it). The operator retries `SET_CHAN_CONFIG`; the stranded
       `cursor.bin` is overwritten on retry or removed on `DELETE`.
     - **Was transient (`persist=false`, the auto-create default).**
-      No `metadata.bin` exists on disk — the channel store only saves
+      No `metadata.bin` exists on disk: the channel store only saves
       metadata when the merged config is persistent (see
       `set_channel_configuration` in
       `crates/server/src/channel/manager.rs`, `save_channel` is gated
@@ -200,7 +200,7 @@ Existing pub/sub state at transition time:
       never happened. The original transient channel state is gone (it
       was in-memory only), so a re-`JOIN` creates a fresh pub/sub
       channel and the operator retries the `SET_CHAN_CONFIG`. The
-      orphaned `cursor.bin` should be cleaned up — either by the
+      orphaned `cursor.bin` should be cleaned up, either by the
       channel directory's lazy-init path on the next save, or via an
       explicit startup sweep (operator may also remove the channel
       directory manually).
@@ -245,11 +245,11 @@ Existing pub/sub state at transition time:
 While a channel is FIFO:
 
 - `BROADCAST` is rejected (`WRONG_TYPE`).
-- `HISTORY` and `CHAN_SEQ` are rejected (`WRONG_TYPE`) — destructive consumption
+- `HISTORY` and `CHAN_SEQ` are rejected (`WRONG_TYPE`); destructive consumption
   has no archive contract.
 - `PUSH` and `POP` are valid.
 - `MEMBER_JOINED` / `MEMBER_LEFT` events still fire on JOIN/LEAVE.
-- `MESSAGE` is **never** pushed — `PUSH` does not fan out to subscribers.
+- `MESSAGE` is **never** pushed; `PUSH` does not fan out to subscribers.
   Consumers must explicitly `POP`.
 - The owner cannot `LEAVE` (returns `OWNER_CANNOT_LEAVE`). The only way out is
   `DELETE`. (Because the owner is always a member, the existing pub/sub
@@ -258,11 +258,11 @@ While a channel is FIFO:
 
 ### Destroying a FIFO Channel
 
-`DELETE` (existing message) is the only path. Authorization is owner-only —
+`DELETE` (existing message) is the only path. Authorization is owner-only,
 already enforced by `delete_channel` in `manager.rs`. On DELETE:
 
 - `CHANNEL_DELETED` event is broadcast to all *other* JOINed members
-  (existing path — `notify_channel_deleted` excludes the deleter's
+  (existing path; `notify_channel_deleted` excludes the deleter's
   resource); the deleting owner receives `DELETE_ACK` instead.
 - Channel metadata, message log segments, head cursor sidecar, and the
   channel's persistence directory are removed.
@@ -270,7 +270,7 @@ already enforced by `delete_channel` in `manager.rs`. On DELETE:
 
 ## Protocol Additions
 
-### Configuration messages — `type` field
+### Configuration messages: `type` field
 
 Two existing structs in `crates/protocol/src/message.rs` are extended:
 
@@ -327,7 +327,7 @@ Errors:
   (see [Head Cursor](#head-cursor)).
 - `NOT_IMPLEMENTED` if `channel_id.domain != local_domain`.
 
-`PUSH_ACK` carries no `seq` — server-side ordering is implicit and not useful
+`PUSH_ACK` carries no `seq`; server-side ordering is implicit and not useful
 to the client.
 
 ### `POP` / `POP_ACK`
@@ -359,7 +359,7 @@ on FIFO) and does **not** carry `from` (always the owner; redundant).
 The cursor advance is fsynced **before** the `POP_ACK` is written to the
 socket. This guarantees no duplication: any element whose advance has been
 fsynced is gone from the queue forever, even if the server crashes
-immediately after. The reverse is **not** guaranteed — a crash between the
+immediately after. The reverse is **not** guaranteed: a crash between the
 cursor fsync and the socket write loses that element (the queue believes it
 was delivered; the client never received it). This is at-most-once: an
 element may be lost, but never duplicated.
@@ -388,14 +388,14 @@ Errors:
   (see [Head Cursor](#head-cursor)).
 - `NOT_IMPLEMENTED` if `channel_id.domain != local_domain`.
 
-Only the owner may query the length. Consumers do not need it — they discover
+Only the owner may query the length. Consumers do not need it; they discover
 emptiness via `QUEUE_EMPTY` on `POP`. The owner uses it to gauge backpressure
 before risking `QUEUE_FULL`.
 
 ### Event: `CHANNEL_RECONFIGURED`
 
 A new `EventKind` variant fired to all JOINed members on any successful
-`SET_CHAN_CONFIG` request (not only type transitions — also `max_clients`,
+`SET_CHAN_CONFIG` request (not only type transitions, also `max_clients`,
 `max_payload_size`, `persist`, etc.).
 
 ```
@@ -475,18 +475,18 @@ On-disk format (16 bytes, fixed):
 
 CRC32 is computed over the first 8 bytes (`next_seq`, little-endian).
 
-The sidecar holds only the **head** of the queue. The **tail** (`last_seq` —
+The sidecar holds only the **head** of the queue. The **tail** (`last_seq`,
 the most recently appended seq) is recovered from the message log; the
 [tail-segment retention invariant](#segment-eviction) ensures it is always
 on disk.
 
 Fields:
 
-- `next_seq` — the lowest seq not yet **committed-as-consumed**: the seq
+- `next_seq`: the lowest seq not yet **committed-as-consumed**, the seq
   the next `POP` will read. Advances when `POP` durably commits the
   consumption (cursor fsync), which happens **before** `POP_ACK` is
   written to the socket. The cursor advance, not `POP_ACK` reaching the
-  client, is the commit point — a crash between cursor fsync and socket
+  client, is the commit point: a crash between cursor fsync and socket
   write loses that element on the consumer side (cursor past it; client
   never received bytes). This is the at-most-once consumer-side loss
   model documented in [Cursor Durability](#cursor-durability).
@@ -494,7 +494,7 @@ Fields:
 **Invariants** (on disk, after every cursor fsync):
 
 - `next_seq >= 1` (sequence numbers are 1-based; `0` is never valid).
-- `next_seq <= log.last_seq() + 1` — the cursor never advances past the
+- `next_seq <= log.last_seq() + 1`: the cursor never advances past the
   most recent durable PUSH (see [Cursor Durability](#cursor-durability)).
 - `next_seq == log.last_seq() + 1` iff the queue is empty.
 - For every seq in `[next_seq ..= log.last_seq()]`, the entry is present
@@ -539,7 +539,7 @@ existing pub/sub `BROADCAST` rules driven by `message_flush_interval`
   crash before the next periodic flush silently drops the most recent
   PUSHes that the producer received ACKs for. On restart,
   `log.last_seq()` simply reflects the last fsynced entry; the lost
-  entries do not surface — same as `BROADCAST`.
+  entries do not surface, same as `BROADCAST`.
 
 The cursor is unaffected in either case: only entries that were never
 POPed (and therefore never contributed to a cursor advance) can be
@@ -569,7 +569,7 @@ where `log.last_seq() - next_seq + 1` would underflow as a `u64`.
 
 `POP` performs an **immediate fsync** on the cursor sidecar before sending
 `POP_ACK`. `PUSH` log writes follow the existing pub/sub durability rules
-driven by `message_flush_interval` — FIFO does **not** diverge from
+driven by `message_flush_interval`; FIFO does **not** diverge from
 `BROADCAST` here. The cursor sidecar is only ever written by `POP` (and
 once at type transition).
 
@@ -577,7 +577,7 @@ once at type transition).
 
 1. Append the entry to the message log buffer.
 2. If `message_flush_interval == 0`: synchronously flush+fsync the log
-   (per the existing `BROADCAST` semantics — see
+   (per the existing `BROADCAST` semantics; see
    [`docs/PROTOCOL.md`](../PROTOCOL.md) and `broadcast_payload` in
    `crates/server/src/channel/manager.rs`). Otherwise the entry stays in
    the log buffer until the next periodic flush.
@@ -588,11 +588,11 @@ Therefore `PUSH_ACK` durability **mirrors `BROADCAST` exactly**:
 - **`message_flush_interval == 0` (the auto-create default):** the entry
   is fsynced before `PUSH_ACK` is sent. A hard crash after `PUSH_ACK`
   cannot lose the entry. (`PUSH_ACK` still does not survive an in-flight
-  network drop — see ACK-loss ambiguity below.)
+  network drop; see ACK-loss ambiguity below.)
 - **`message_flush_interval > 0`:** the entry sits in the log buffer
   until the next periodic flush (or until a concurrent `POP` forces one,
   see the `POP` path below). A hard crash before the next flush silently
-  drops the entry — same as `BROADCAST`.
+  drops the entry, same as `BROADCAST`.
 
 The choice between the two is the operator's, configured via
 `SET_CHAN_CONFIG`; FIFO does not impose its own value.
@@ -617,7 +617,7 @@ address this server-side; out of scope for v1 (see
    already covered the entry, this is a cheap no-op. **This step is
    required:** without it, `POP` could read a buffered (not-yet-fsynced)
    entry, advance the cursor durably, and crash before the log was
-   flushed — leaving `cursor.next_seq > log.last_seq() + 1` on disk,
+   flushed, leaving `cursor.next_seq > log.last_seq() + 1` on disk,
    which the recovery model treats as corruption.
 3. Update `cursor.bin` with `next_seq = previous_next_seq + 1`.
 4. `fsync` `cursor.bin`.
@@ -626,11 +626,11 @@ address this server-side; out of scope for v1 (see
 A crash between (4) and (5) loses that element on the consumer side
 (cursor advanced; client never received bytes). This is the at-most-once
 consumer-side loss model: **no duplication, possible loss**. The
-no-duplication contract is the load-bearing one — at no point can two
+no-duplication contract is the load-bearing one: at no point can two
 clients (or one client across retries) receive the same physical queue
 element.
 
-**Cursor write protocol** (atomic, mirrors the channel-store write — see
+**Cursor write protocol** (atomic, mirrors the channel-store write; see
 [CHANNEL_STORE.md](CHANNEL_STORE.md)):
 
 1. Write to `cursor.bin.tmp`.
@@ -639,7 +639,7 @@ element.
 4. `fsync` the parent directory.
 
 **Throughput cost.** `PUSH` matches `BROADCAST` semantics across both
-flush modes — synchronous fsync per `PUSH` when
+flush modes: synchronous fsync per `PUSH` when
 `message_flush_interval == 0`, batched flushing on the configured
 interval otherwise. `POP` costs **one** cursor fsync in the common
 case; in the worst case (POP racing ahead of the background flusher),
@@ -655,7 +655,7 @@ FIFO eviction has two ends:
 - **Tail eviction (existing pub/sub behavior) is disabled.** `PUSH` is
   rejected with `QUEUE_FULL` whenever the **logical queue depth** would
   exceed `max_persist_messages` after appending. Logical depth comes from
-  the cursor's `next_seq` and the log's `last_seq()` — **not** from the
+  the cursor's `next_seq` and the log's `last_seq()`, **not** from the
   physical number of entries on disk. Popped elements remain on disk until
   their segment is head-evicted, so a check against physical retention
   would spuriously reject `PUSH`es after consumers have drained part of a
@@ -692,18 +692,18 @@ channel's type (or on a flag passed at log creation time).
 `PersistedChannel` (defined in `crates/server/src/channel/store.rs`; used
 by `file_store.rs`) gains one new field:
 
-- `channel_type: ChannelType` — enum `{ PubSub, Fifo }`.
+- `channel_type: ChannelType`: enum `{ PubSub, Fifo }`.
 
 This is a positional postcard schema change. Because the project is
 **pre-production**, no migration path is required: existing on-disk
 `metadata.bin` files written before this change become unreadable and the
 expected operator action is to wipe `<channels_root>` and let the server
 start fresh. (If/when the project ships, a versioned envelope or per-version
-decoder will need to be introduced — out of scope here.)
+decoder will need to be introduced; out of scope here.)
 
 The owner is already persisted in `PersistedChannel`. No change there.
 
-The cursor is **not** part of the postcard-encoded metadata file — it is its
+The cursor is **not** part of the postcard-encoded metadata file; it is its
 own sidecar (`cursor.bin`, see above) so that the high-frequency cursor fsync
 does not require rewriting the larger metadata blob.
 
@@ -714,7 +714,7 @@ The following pub/sub paths must branch on channel type:
 | Path                                  | Pub/Sub                          | FIFO                                |
 | ------------------------------------- | -------------------------------- | ----------------------------------- |
 | `LEAVE` handler (manager.rs)          | Removes member; clears owner if owner leaves; auto-deletes channel if last member | Returns `OWNER_CANNOT_LEAVE` if owner; otherwise removes member. Auto-delete-on-empty is implicitly unreachable since the owner is always a member. |
-| `remove_member` (manager.rs)          | Clears `owner` if owner is the leaver | Never reached for owner — LEAVE rejects upstream |
+| `remove_member` (manager.rs)          | Clears `owner` if owner is the leaver | Never reached for owner; LEAVE rejects upstream |
 | Empty-channel auto-delete sites (manager.rs) | Removes channel | Unreachable for FIFO (precondition `member_count == 0` cannot be met). Defensive type-gate is optional. |
 | Message log eviction policy           | Tail-evict at cap                | Reject PUSH at cap (`QUEUE_FULL`)    |
 | `BROADCAST` handler                   | Append + fan out                 | `WRONG_TYPE`                         |
@@ -761,13 +761,13 @@ New metrics under the `narwhal` channel prefix:
 
 | Metric                        | Type      | Notes                                  |
 | ----------------------------- | --------- | -------------------------------------- |
-| `fifo_pushes{result}`         | Counter   | One label per `PUSH` outcome — see below. |
-| `fifo_pops{result}`           | Counter   | One label per `POP` outcome — see below.  |
+| `fifo_pushes{result}`         | Counter   | One label per `PUSH` outcome; see below. |
+| `fifo_pops{result}`           | Counter   | One label per `POP` outcome; see below.  |
 | `fifo_queue_depth`            | Gauge     | Per-channel? Or aggregate? (see implementation note) |
 | `fifo_cursor_fsync_seconds`   | Histogram | Wall time of cursor fsync.             |
 
 **`fifo_pushes{result}` labels** (must cover every documented `PUSH`
-outcome — see [PUSH errors](#push--push_ack)):
+outcome; see [PUSH errors](#push--push_ack)):
 
 - `success`
 - `channel_not_found`
@@ -780,7 +780,7 @@ outcome — see [PUSH errors](#push--push_ack)):
 - `not_implemented` (non-local domain)
 
 **`fifo_pops{result}` labels** (must cover every documented `POP`
-outcome — see [POP errors](#pop--pop_ack)):
+outcome; see [POP errors](#pop--pop_ack)):
 
 - `success`
 - `channel_not_found`
@@ -794,7 +794,7 @@ outcome — see [POP errors](#pop--pop_ack)):
 Implementations must emit exactly one of these labels per call. If a
 new outcome is added in the future and the implementation has not yet
 been updated, it should be bucketed into a single `other` label rather
-than dropped — and the doc updated alongside.
+than dropped, and the doc updated alongside.
 
 Per-channel gauges blow up cardinality. The `fifo_queue_depth` gauge
 should be aggregate (sum across channels) or omitted in favor of an
@@ -856,7 +856,7 @@ A non-binding outline of the work units. Order is suggestive, not prescriptive.
      written + fsynced first, then `metadata.bin` updated + fsynced,
      then `SET_CHAN_CONFIG_ACK` sent. A crash before metadata is
      written must leave the channel as pub/sub (a stranded
-     `cursor.bin` is acceptable — pub/sub ignores it).
+     `cursor.bin` is acceptable; pub/sub ignores it).
    - Implement type-aware branches in `LEAVE` (reject for owner with
      `OWNER_CANNOT_LEAVE`), `BROADCAST`, `HISTORY` / `CHAN_SEQ` (all return
      `WRONG_TYPE`).
@@ -874,7 +874,7 @@ A non-binding outline of the work units. Order is suggestive, not prescriptive.
      specified seq, used by `POP` when the entry it is reading is not
      yet durable.
    - `PUSH` durability follows existing pub/sub batching driven by
-     `message_flush_interval` — no FIFO-specific change.
+     `message_flush_interval`; no FIFO-specific change.
 4. **Cursor sidecar:**
    - 16-byte layout: `next_seq` (u64-LE) + `crc32` (u32-LE) + 4-byte
      zero pad. CRC32 is over `next_seq` only.
@@ -898,7 +898,7 @@ A non-binding outline of the work units. Order is suggestive, not prescriptive.
    - Add `channel_type: ChannelType` (enum `{ PubSub, Fifo }`) to
      `PersistedChannel` (defined in `store.rs`). Existing on-disk
      `metadata.bin` files written before this change will fail to
-     decode — acceptable because the project is pre-production;
+     decode. Acceptable because the project is pre-production;
      operators wipe `<channels_root>` before upgrading. (A versioned
      envelope can be introduced later when production durability is
      required; out of scope here.)
@@ -935,7 +935,7 @@ A non-binding outline of the work units. Order is suggestive, not prescriptive.
      elements (let the background flusher run), POP all N, restart, then
      `PUSH` one more element and verify it is assigned `seq = N + 1`. This
      exercises that the segment containing `log.last_seq()` is retained
-     across drain — without the invariant, head-eviction would remove the
+     across drain. Without the invariant, head-eviction would remove the
      last segment and the seq counter would reset on restart.
    - **Force-flush-on-POP test:** with `message_flush_interval` set to a
      long value (e.g. 60s), issue a `PUSH` followed immediately by a
@@ -953,7 +953,7 @@ A non-binding outline of the work units. Order is suggestive, not prescriptive.
      `kill` does not discard. Reliably observing the loss requires an
      OS-level crash (VM reset / power cut), which is not in the unit/
      integration test budget. Keep this case to a contract assertion
-     only — do not write a test that expects the entry to be absent.
+     only; do not write a test that expects the entry to be absent.
    - Crash-during-POP test (kill between cursor fsync and `POP_ACK` socket
      write): verify the next consumer does **not** see the lost element
      (no duplication is the load-bearing contract).

--- a/docs/architecture/MESSAGE_LOG.md
+++ b/docs/architecture/MESSAGE_LOG.md
@@ -1,4 +1,4 @@
-# Message Log — Architecture Specification
+# Message Log: Architecture Specification
 
 > **Status:** Implemented.
 > **Related PRs:** [#221](https://github.com/lonewolf-io/narwhal/pull/221) (HISTORY/CHAN_SEQ protocol), [#227](https://github.com/lonewolf-io/narwhal/pull/227) (FileMessageLog implementation)
@@ -22,7 +22,7 @@
   - [Segment Roll](#segment-roll)
 - [Read Path](#read-path)
   - [Index Lookup](#index-lookup)
-  - [EntryReader — Zero-Allocation Positioned Reads](#entryreader--zero-allocation-positioned-reads)
+  - [EntryReader: Zero-Allocation Positioned Reads](#entryreader-zero-allocation-positioned-reads)
   - [Visitor Invocation](#visitor-invocation)
 - [Eviction](#eviction)
 - [Recovery](#recovery)
@@ -40,8 +40,8 @@ The message log is a per-channel, segmented, append-only storage engine that
 persists broadcast messages for channels with persistence enabled. It serves two
 protocol operations introduced in PR #221:
 
-- **`HISTORY`** — retrieve archived messages from a channel.
-- **`CHAN_SEQ`** — query the available sequence range of a channel's log.
+- **`HISTORY`**: retrieve archived messages from a channel.
+- **`CHAN_SEQ`**: query the available sequence range of a channel's log.
 
 Each persistent channel maintains its own message log as a set of segment files
 with companion sparse index files, stored in the channel's existing directory.
@@ -140,8 +140,8 @@ Each entry is a self-contained binary record:
 **Fixed overhead per entry: 26 bytes.**
 
 **Omitted fields:**
-- **`channel`** — implicit from the directory/file path.
-- **`history_id`** — injected by the caller at read time, not a property of the stored message.
+- **`channel`**: implicit from the directory/file path.
+- **`history_id`**: injected by the caller at read time, not a property of the stored message.
 
 ### Sparse Index Files
 
@@ -183,7 +183,7 @@ Index files are accessed via `mmap` (using the `memmap2` crate), mirroring how
 Apache Kafka manages its offset indexes. There are two distinct modes depending
 on whether the segment is active or sealed:
 
-**Active segment — read-write `MmapMut`:**
+**Active segment, read-write `MmapMut`:**
 
 When a new segment is created, its `.idx` file is **pre-allocated** to the
 maximum capacity it could ever need, then memory-mapped read-write:
@@ -207,7 +207,7 @@ beyond `SEGMENT_MAX_BYTES`. If that final overshooting append also crosses an
 index interval boundary while the index is at peak utilization, the
 implementation has no slot left to record it. The append path guards with
 `pos + INDEX_ENTRY_SIZE <= mmap.len()` and silently drops the would-be index
-entry — correctness is preserved (no out-of-bounds write, the segment rolls
+entry. Correctness is preserved (no out-of-bounds write, the segment rolls
 on the next append), but the un-indexed tail of that segment will be reached
 by a linear scan from the previous index entry. The scan distance is bounded
 by `INDEX_INTERVAL_BYTES + max_entry_size`. Bumping the formula by one slot
@@ -216,12 +216,12 @@ pre-allocation per segment.
 
 New index entries are written directly into the mmap at the current write
 position (`active_idx_write_pos`). This avoids `write()` syscalls for index
-updates — the kernel handles page dirtying and writeback. The active `.idx`
+updates; the kernel handles page dirtying and writeback. The active `.idx`
 file handle is kept open and durability is enforced with async
 `sync_all().await` on that file (instead of synchronous `mmap.flush()`), so
 flush/roll do not block the shard runtime thread.
 
-**Sealed segments — read-only `Mmap`:**
+**Sealed segments, read-only `Mmap`:**
 
 When a segment is rolled (finalized), the index lifecycle is:
 
@@ -244,7 +244,7 @@ new entries continue from where the previous session left off.
 **Binary search:**
 
 Both `Mmap` (sealed) and `MmapMut` (active) are searched with the same
-`index_lookup_in(&[u8], target_relative_seq)` function — a standard binary
+`index_lookup_in(&[u8], target_relative_seq)` function: a standard binary
 search for the largest `relative_seq <= target`. For the active index, the
 slice is bounded to `&mmap[..active_idx_write_pos]` to exclude the
 zero-filled pre-allocated tail.
@@ -332,7 +332,7 @@ pub trait MessageLog: 'static {
 - `read` is async (io_uring positioned reads via `EntryReader`) and the visitor
   is also async, allowing it to perform I/O (e.g., sending messages) between
   entry reads.
-- No `direction` parameter — the client computes the appropriate `from_seq`
+- No `direction` parameter; the client computes the appropriate `from_seq`
   using `first_seq`/`last_seq` from the `CHAN_SEQ` response. The log always
   reads forward.
 
@@ -353,7 +353,7 @@ pub trait LogVisitor {
 ```
 
 The visitor borrows entry data directly from the `EntryReader`'s pre-allocated
-buffers — **zero heap allocations** on the read hot path. The `async` signature
+buffers, with **zero heap allocations** on the read hot path. The `async` signature
 allows visitors to perform async work (e.g., sending messages over the network)
 without blocking.
 
@@ -375,7 +375,7 @@ to the transmitter, channel name, `history_id`, and the payload pool:
 └────────────────────────────────────────────────────────────┘
 ```
 
-The "no heap allocation" guarantee applies to the **payload** path — the
+The "no heap allocation" guarantee applies to the **payload** path: the
 `PoolBuffer` is recycled across reads. The frame header path still allocates
 small `StringAtom`s (decoding `from`, cloning `channel` and `history_id`) per
 entry; those allocations are intentional and bounded.
@@ -384,7 +384,7 @@ If `entry.from` contains bytes that are not valid UTF-8 (only possible if a
 corrupt entry passes CRC validation, e.g. across a binary-format change),
 `std::str::from_utf8` returns an error. The visitor propagates it, `read()`
 returns `Err`, and `ChannelShard::history()` exits *before* sending
-`HistoryAck` — the client receives no `HISTORY_ACK` for that request and must
+`HistoryAck`. The client receives no `HISTORY_ACK` for that request and must
 treat the in-flight `MESSAGE` frames already received as the truncated
 result. Operators should treat repeated UTF-8 decode errors as a signal of
 on-disk corruption.
@@ -401,7 +401,7 @@ pub trait MessageLogFactory: Clone + Send + Sync + 'static {
 
 The factory holds `base_dir` and `max_payload_size` at construction time.
 `create()` is async because it performs recovery (scanning segment files,
-validating CRC checksums, rebuilding indexes) using `compio::fs` I/O — and
+validating CRC checksums, rebuilding indexes) using `compio::fs` I/O, and
 it returns `anyhow::Result<Self::Log>` because that recovery may fail (e.g.
 unable to open the active segment for writes or memory-map its index, see
 [Recovery](#recovery)). On `Err`, callers refuse to bring the affected
@@ -427,7 +427,7 @@ append(message, payload, max_messages)
 ```
 
 Writes use **positioned I/O** via `compio::fs::File::write_all_at()` (io_uring
-`WRITE` op). There is no append mode in compio — the file offset is tracked
+`WRITE` op). There is no append mode in compio; the file offset is tracked
 in-memory as `seg.file_size` and passed explicitly to each write. This is safe
 under the single-threaded shard actor model. Data is visible to subsequent reads
 immediately (even before fsync) because both reads and writes operate on the
@@ -443,7 +443,7 @@ same file through the kernel page cache.
 Both syncs run through compio/io_uring and avoid synchronous `mmap.flush()`
 inside async shard code.
 
-**Durability guarantee:** same as Kafka — data survives process crashes (data is
+**Durability guarantee:** same as Kafka. Data survives process crashes (data is
 in the kernel page cache) but not power loss without fsync. The existing flush
 mechanism (immediate when `message_flush_interval=0`, or periodic via background
 task) is unchanged.
@@ -451,7 +451,7 @@ task) is unchanged.
 **Linux dependency.** Skipping `mmap.flush()` (i.e. `msync`) and relying on
 `sync_all()` of the underlying file handle to flush pages dirtied through
 `MmapMut` is correct on Linux because file-backed mmaps share the unified
-page cache with regular file I/O — `fsync(2)` flushes all dirty pages backing
+page cache with regular file I/O: `fsync(2)` flushes all dirty pages backing
 the file regardless of how they were dirtied. POSIX does not guarantee this
 in general; the design assumes the io_uring/Linux runtime environment
 already required by the rest of the project.
@@ -501,7 +501,7 @@ To read from `from_seq`:
    or the segment ends (then continue to next segment)
 ```
 
-### EntryReader — Zero-Allocation Positioned Reads
+### EntryReader: Zero-Allocation Positioned Reads
 
 Instead of chunk-based buffered reading, the implementation uses an `EntryReader`
 struct that performs **two positioned reads per entry** via `compio::fs::File`
@@ -567,7 +567,7 @@ before reducing it.
 ```
 
 Buffers are moved into compio via `std::mem::take()` for each I/O op and
-reclaimed from `BufResult` — the standard compio buffer-ownership pattern.
+reclaimed from `BufResult`, the standard compio buffer-ownership pattern.
 
 ### Visitor Invocation
 
@@ -599,7 +599,7 @@ retention window. This means actual disk usage may slightly exceed
 messages), but the trade-off is clean O(1) eviction with no rewriting.
 
 **Active-segment invariant:** the active (last) segment is **never** evicted,
-even if all of its entries fall outside the retention window — there must
+even if all of its entries fall outside the retention window; there must
 always be a segment to append into. The worst-case on-disk overhead per
 channel is therefore approximately one segment's worth of data: about
 `SEGMENT_MAX_BYTES` (128 MiB) above `max_persist_messages * avg_entry_size`,
@@ -611,14 +611,14 @@ or under bursty traffic where a single segment fills before
 `max_persist_messages` worth of newer messages arrive. Operators sizing disk
 should plan accordingly.
 
-A `max_persist_messages` of `0` is interpreted as **no eviction** — the log
+A `max_persist_messages` of `0` is interpreted as **no eviction**: the log
 grows unbounded. This is the de facto behavior of `MessageLog::append` when
 called with `max_messages == 0`.
 
 ## Recovery
 
 On startup, the message log restores its state from disk. Recovery is **fully
-async** — all file I/O uses `compio::fs` (io_uring), except for `read_dir`
+async**: all file I/O uses `compio::fs` (io_uring), except for `read_dir`
 (no compio equivalent, uses `std::fs`).
 
 An `EntryReader` and an index rebuild buffer (`Vec<u8>`) are created once at the
@@ -804,8 +804,8 @@ owned by a shard actor, and the shard processes commands sequentially. There is
 no concurrent read/write access to a channel's message log.
 
 - No locks, no atomics.
-- `Rc<MessageLog>` (not `Arc`) — consistent with the existing `Channel` struct.
-- Interior mutability via `RefCell` — provides runtime borrow checking that
+- `Rc<MessageLog>` (not `Arc`); consistent with the existing `Channel` struct.
+- Interior mutability via `RefCell`; provides runtime borrow checking that
   catches violations in debug builds. The `MessageLog` trait exposes `&self`
   methods; `FileMessageLog` uses `RefCell<Inner>` to mutate internal state.
 - `read()` and `append()` are never called concurrently for the same channel.
@@ -836,7 +836,7 @@ and survives_restart) in `crates/server/tests/c2s_channel_persistence.rs` and
 
 Tests use `tempfile::TempDir` for isolated file system state.
 
-Existing tests using `NoopMessageLog` remain unchanged — they verify channel
+Existing tests using `NoopMessageLog` remain unchanged; they verify channel
 manager logic independently of persistence.
 
 ## File Locations


### PR DESCRIPTION
## Summary
- One-time cleanup applying the comment-style rule (`AGENTS.md` rule 4) across the existing codebase.
- Removes em dashes (—) and ellipses (`...`, `…`) from Rust comments and markdown prose.
- Substitutions are context-aware: `:` for label/explanation, `;` for tightly related independent clauses, `,` for parentheticals, `.` to split into sentences.

