### PR TITLE
chore: release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Narwhal will be documented in this file.
 
 ## Unreleased
 
+## 0.6.1 (2026-05-01)
+
 * [CHANGE]: Replace the multi-value `operations` string list on `S2M_CONNECT_ACK` with a single `operation_mask` u64 bitmask. Bit positions are now the authoritative wire contract, frozen in `PROTOCOL.md`'s new `Operation Bit Assignments` section. Breaking wire change with no compatibility shim. [#283](https://github.com/lonewolf-io/narwhal/pull/283)
 * [ENHANCEMENT]: Surface sealed message-log segments whose recovery validation scan terminates before EOF (CRC mismatch, unreadable header, oversized declared lengths, truncated tail, or I/O error) via a new `message_log_sealed_segment_truncations` counter and a `tracing::warn!`, so silent data loss past the validated region shows up as telemetry instead of being discovered later via missing history. [#269](https://github.com/lonewolf-io/narwhal/pull/269)
 * [BUGFIX]: Stop unconditionally forwarding broadcast payloads to the attached modulator. The C2S dispatcher now caches the modulator's declared `Operations` once at startup and gates the forward call on `Operation::ForwardBroadcastPayload`. [#275](https://github.com/lonewolf-io/narwhal/pull/275)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-benchmark"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-client"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-modulator"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-protocol"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-protocol-macros"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-test-util"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-util"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ To trade strict per-message durability for higher throughput, add `--flush-inter
 
 ## Project Status
 
-**Current Version: 0.6.0 (Alpha)**
+**Current Version: 0.6.1 (Alpha)**
 
 Narwhal is in active development and currently in **alpha** stage. While the core functionality is working and tested, please note:
 

--- a/crates/benchmark/Cargo.toml
+++ b/crates/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-benchmark"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-client"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-common"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/modulator/Cargo.toml
+++ b/crates/modulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-modulator"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/protocol-macros/Cargo.toml
+++ b/crates/protocol-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-protocol-macros"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-protocol"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-server"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/test-util/Cargo.toml
+++ b/crates/test-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-test-util"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-util"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/examples/modulator/Cargo.lock
+++ b/examples/modulator/Cargo.lock
@@ -176,7 +176,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "broadcast-payload-csv-validator"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "broadcast-payload-json-validator"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-client"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-modulator"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-protocol"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-protocol-macros"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-util"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1304,7 +1304,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain-authenticator"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "private-payload-sender"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/examples/modulator/broadcast-payload-csv-validator/Cargo.toml
+++ b/examples/modulator/broadcast-payload-csv-validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "broadcast-payload-csv-validator"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/examples/modulator/broadcast-payload-json-validator/Cargo.toml
+++ b/examples/modulator/broadcast-payload-json-validator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "broadcast-payload-json-validator"
 description = "A JSON payload validator for Narwhal protocol"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/examples/modulator/plain-authenticator/Cargo.toml
+++ b/examples/modulator/plain-authenticator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plain-authenticator"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/examples/modulator/private-payload-sender/Cargo.toml
+++ b/examples/modulator/private-payload-sender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "private-payload-sender"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "BSD-3-Clause"
 


### PR DESCRIPTION
## Summary

Release 0.6.1.

- Move the `Unreleased` CHANGELOG entries (1 CHANGE, 1 ENHANCEMENT, 11 BUGFIX) under `## 0.6.1 (2026-05-01)`
- Bump version `0.6.0` → `0.6.1` across all 13 workspace and example crates
- Refresh both `Cargo.lock` files
- Update `Current Version` in `README.md`