### PR TITLE
feat(server): add FIFO channels transition slice (PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Narwhal will be documented in this file.
 
 ## Unreleased
 
+* [FEATURE]: FIFO Channels — transition slice. A pub/sub channel can be promoted to a FIFO work-queue via `SET_CHAN_CONFIG type=fifo` (one-way; requires `persist=true` and `max_persist_messages > 0`). Adds error reasons `QUEUE_EMPTY`, `QUEUE_FULL`, `WRONG_TYPE`, `CURSOR_RECOVERY_REQUIRED`; event `CHANNEL_RECONFIGURED` (fires on any successful CHAN_CONFIG change, suppressed on no-op); `type` parameter on `CHAN_CONFIG` (read response, required) and `SET_CHAN_CONFIG` (mutating, optional). After transition, `BROADCAST` / `HISTORY` / `CHAN_SEQ` return `WRONG_TYPE`, and owner `LEAVE` auto-deletes the channel. The data plane (`PUSH` / `POP` / `GET_CHAN_LEN`) and the `protocol.md` update ship in a follow-up PR; FIFO is not production-ready until that lands.
+
 ## 0.6.1 (2026-05-01)
 
 * [CHANGE]: Replace the multi-value `operations` string list on `S2M_CONNECT_ACK` with a single `operation_mask` u64 bitmask. Bit positions are now the authoritative wire contract, frozen in `PROTOCOL.md`'s new `Operation Bit Assignments` section. Breaking wire change with no compatibility shim. [#283](https://github.com/lonewolf-io/narwhal/pull/283)

--- a/crates/client/src/compio/c2s.rs
+++ b/crates/client/src/compio/c2s.rs
@@ -340,6 +340,7 @@ impl C2sClient {
       max_persist_messages,
       persist,
       message_flush_interval,
+      r#type: None,
     });
 
     let handle = self.client.send_message(message, None).await?;

--- a/crates/client/src/tokio/c2s.rs
+++ b/crates/client/src/tokio/c2s.rs
@@ -350,6 +350,7 @@ impl C2sClient {
       max_persist_messages,
       persist,
       message_flush_interval,
+      r#type: None,
     });
 
     let handle = self.client.send_message(message, None).await?;

--- a/crates/protocol/src/deserialize.rs
+++ b/crates/protocol/src/deserialize.rs
@@ -295,8 +295,8 @@ mod tests {
     },
     TestCase {
             name: "CHAN_CONFIG",
-            input: b"CHAN_CONFIG id=1 channel=!1@localhost max_clients=100 max_payload_size=16",
-            expected: Ok(Message::ChannelConfiguration(ChannelConfigurationParameters { id: 1, channel: StringAtom::from("!1@localhost"),  max_clients: 100, max_payload_size:16, ..Default::default() })),
+            input: b"CHAN_CONFIG id=1 channel=!1@localhost max_clients=100 max_payload_size=16 type=pubsub",
+            expected: Ok(Message::ChannelConfiguration(ChannelConfigurationParameters { id: 1, channel: StringAtom::from("!1@localhost"),  max_clients: 100, max_payload_size:16, r#type: StringAtom::from("pubsub"), ..Default::default() })),
         },
     TestCase {
             name: "CONNECT",

--- a/crates/protocol/src/error.rs
+++ b/crates/protocol/src/error.rs
@@ -59,6 +59,17 @@ pub enum ErrorReason {
   ResourceLimitReached,
   /// The response exceeds the maximum message size limit.
   ResponseTooLarge,
+  /// POP attempted on an empty FIFO channel queue.
+  QueueEmpty,
+  /// PUSH attempted on a FIFO channel whose queue is at `max_persist_messages`.
+  QueueFull,
+  /// Operation requested on a channel whose declared type does not support it
+  /// (e.g. BROADCAST on a FIFO channel, PUSH on a pub/sub channel).
+  WrongType,
+  /// FIFO data-plane operation on a channel whose head cursor failed recovery.
+  /// Operator must restore `cursor.bin`, write a fresh sidecar, or DELETE the
+  /// channel before normal operation can resume.
+  CursorRecoveryRequired,
 }
 
 impl From<ErrorReason> for StringAtom {
@@ -94,6 +105,10 @@ impl From<ErrorReason> for &str {
       ErrorReason::UserNotRegistered => "USER_NOT_REGISTERED",
       ErrorReason::ResourceLimitReached => "RESOURCE_LIMIT_REACHED",
       ErrorReason::ResponseTooLarge => "RESPONSE_TOO_LARGE",
+      ErrorReason::QueueEmpty => "QUEUE_EMPTY",
+      ErrorReason::QueueFull => "QUEUE_FULL",
+      ErrorReason::WrongType => "WRONG_TYPE",
+      ErrorReason::CursorRecoveryRequired => "CURSOR_RECOVERY_REQUIRED",
     }
   }
 }
@@ -135,6 +150,10 @@ impl FromStr for ErrorReason {
       "USER_NOT_REGISTERED" => Ok(ErrorReason::UserNotRegistered),
       "RESOURCE_LIMIT_REACHED" => Ok(ErrorReason::ResourceLimitReached),
       "RESPONSE_TOO_LARGE" => Ok(ErrorReason::ResponseTooLarge),
+      "QUEUE_EMPTY" => Ok(ErrorReason::QueueEmpty),
+      "QUEUE_FULL" => Ok(ErrorReason::QueueFull),
+      "WRONG_TYPE" => Ok(ErrorReason::WrongType),
+      "CURSOR_RECOVERY_REQUIRED" => Ok(ErrorReason::CursorRecoveryRequired),
       _ => anyhow::bail!("unknown error reason: {}", s),
     }
   }
@@ -195,6 +214,10 @@ impl Error {
         | ErrorReason::ServerOverloaded
         | ErrorReason::ResourceLimitReached
         | ErrorReason::ResponseTooLarge
+        | ErrorReason::QueueEmpty
+        | ErrorReason::QueueFull
+        | ErrorReason::WrongType
+        | ErrorReason::CursorRecoveryRequired
     )
   }
 }
@@ -230,3 +253,54 @@ impl std::fmt::Display for Error {
 }
 
 impl std::error::Error for Error {}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn round_trip(reason: ErrorReason) {
+    let s: &str = reason.into();
+    let parsed = ErrorReason::from_str(s).unwrap();
+    assert_eq!(parsed, reason);
+  }
+
+  #[test]
+  fn round_trip_queue_empty() {
+    round_trip(ErrorReason::QueueEmpty);
+    let s: &str = ErrorReason::QueueEmpty.into();
+    assert_eq!(s, "QUEUE_EMPTY");
+  }
+
+  #[test]
+  fn round_trip_queue_full() {
+    round_trip(ErrorReason::QueueFull);
+    let s: &str = ErrorReason::QueueFull.into();
+    assert_eq!(s, "QUEUE_FULL");
+  }
+
+  #[test]
+  fn round_trip_wrong_type() {
+    round_trip(ErrorReason::WrongType);
+    let s: &str = ErrorReason::WrongType.into();
+    assert_eq!(s, "WRONG_TYPE");
+  }
+
+  #[test]
+  fn round_trip_cursor_recovery_required() {
+    round_trip(ErrorReason::CursorRecoveryRequired);
+    let s: &str = ErrorReason::CursorRecoveryRequired.into();
+    assert_eq!(s, "CURSOR_RECOVERY_REQUIRED");
+  }
+
+  #[test]
+  fn fifo_errors_are_recoverable() {
+    for reason in [
+      ErrorReason::QueueEmpty,
+      ErrorReason::QueueFull,
+      ErrorReason::WrongType,
+      ErrorReason::CursorRecoveryRequired,
+    ] {
+      assert!(Error::new(reason).is_recoverable(), "{reason} should be recoverable");
+    }
+  }
+}

--- a/crates/protocol/src/error.rs
+++ b/crates/protocol/src/error.rs
@@ -294,12 +294,9 @@ mod tests {
 
   #[test]
   fn fifo_errors_are_recoverable() {
-    for reason in [
-      ErrorReason::QueueEmpty,
-      ErrorReason::QueueFull,
-      ErrorReason::WrongType,
-      ErrorReason::CursorRecoveryRequired,
-    ] {
+    for reason in
+      [ErrorReason::QueueEmpty, ErrorReason::QueueFull, ErrorReason::WrongType, ErrorReason::CursorRecoveryRequired]
+    {
       assert!(Error::new(reason).is_recoverable(), "{reason} should be recoverable");
     }
   }

--- a/crates/protocol/src/event.rs
+++ b/crates/protocol/src/event.rs
@@ -30,6 +30,13 @@ pub enum EventKind {
   /// This event is triggered when the channel owner explicitly deletes the
   /// channel. All members are removed and the channel is destroyed.
   ChannelDeleted,
+
+  /// Indicates that a channel's configuration has been changed.
+  ///
+  /// Fires after any successful `SET_CHAN_CONFIG` (including the pub/sub →
+  /// FIFO transition). The payload only carries the channel name; clients
+  /// re-query `GET_CHAN_CONFIG` to read the new configuration.
+  ChannelReconfigured,
 }
 
 impl std::fmt::Display for EventKind {
@@ -52,6 +59,7 @@ impl From<EventKind> for &str {
       EventKind::MemberJoined => "MEMBER_JOINED",
       EventKind::MemberLeft => "MEMBER_LEFT",
       EventKind::ChannelDeleted => "CHANNEL_DELETED",
+      EventKind::ChannelReconfigured => "CHANNEL_RECONFIGURED",
     }
   }
 }
@@ -72,6 +80,7 @@ impl FromStr for EventKind {
       "MEMBER_JOINED" => Ok(EventKind::MemberJoined),
       "MEMBER_LEFT" => Ok(EventKind::MemberLeft),
       "CHANNEL_DELETED" => Ok(EventKind::ChannelDeleted),
+      "CHANNEL_RECONFIGURED" => Ok(EventKind::ChannelReconfigured),
       _ => anyhow::bail!("unknown event kind: {}", s),
     }
   }
@@ -130,5 +139,18 @@ impl From<Event> for Message {
       nid: val.nid.clone(),
       owner: val.owner,
     })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn round_trip_channel_reconfigured() {
+    let s: &str = EventKind::ChannelReconfigured.into();
+    assert_eq!(s, "CHANNEL_RECONFIGURED");
+    let parsed = EventKind::from_str(s).unwrap();
+    assert_eq!(parsed, EventKind::ChannelReconfigured);
   }
 }

--- a/crates/protocol/src/message.rs
+++ b/crates/protocol/src/message.rs
@@ -158,6 +158,9 @@ pub struct ChannelConfigurationParameters {
   pub max_persist_messages: u32,
   pub persist: bool,
   pub message_flush_interval: u32,
+
+  #[param(name = "type", validate = "non_empty")]
+  pub r#type: StringAtom,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, ProtocolMessageParameters)]
@@ -578,6 +581,9 @@ pub struct SetChannelConfigurationParameters {
   pub max_persist_messages: Option<u32>,
   pub persist: Option<bool>,
   pub message_flush_interval: Option<u32>,
+
+  #[param(name = "type")]
+  pub r#type: Option<StringAtom>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, ProtocolMessageParameters)]
@@ -1065,6 +1071,68 @@ impl Message {
       Message::ModDirect(params) => params.id,
 
       _ => None,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::{deserialize::deserialize, serialize::serialize};
+  use std::io::Cursor;
+
+  fn roundtrip(msg: Message) -> Message {
+    let mut buf = vec![0u8; 1024];
+    let n = serialize(&msg, &mut buf).expect("serialize");
+    // serialize emits a trailing '\n'; the framing layer strips it before
+    // deserialize, so do the same here.
+    let end = if n > 0 && buf[n - 1] == b'\n' { n - 1 } else { n };
+    deserialize(Cursor::new(&buf[..end])).expect("deserialize")
+  }
+
+  #[test]
+  fn set_channel_configuration_with_type_round_trip() {
+    let original = Message::SetChannelConfiguration(SetChannelConfigurationParameters {
+      id: 42,
+      channel: "!c@localhost".into(),
+      max_clients: Some(8),
+      r#type: Some("fifo".into()),
+      ..Default::default()
+    });
+    assert_eq!(roundtrip(original.clone()), original);
+  }
+
+  #[test]
+  fn set_channel_configuration_without_type_round_trip() {
+    let original = Message::SetChannelConfiguration(SetChannelConfigurationParameters {
+      id: 42,
+      channel: "!c@localhost".into(),
+      max_clients: Some(8),
+      r#type: None,
+      ..Default::default()
+    });
+    assert_eq!(roundtrip(original.clone()), original);
+  }
+
+  #[test]
+  fn channel_configuration_emits_type_field() {
+    let params = ChannelConfigurationParameters {
+      id: 1,
+      channel: "!c@localhost".into(),
+      max_clients: 1,
+      max_payload_size: 1,
+      max_persist_messages: 1,
+      persist: true,
+      message_flush_interval: 0,
+      r#type: "fifo".into(),
+    };
+    let msg = Message::ChannelConfiguration(params.clone());
+    let round = roundtrip(msg);
+    if let Message::ChannelConfiguration(p) = round {
+      assert_eq!(p.r#type.as_ref(), "fifo");
+      assert_eq!(p, params);
+    } else {
+      panic!("expected ChannelConfiguration");
     }
   }
 }

--- a/crates/protocol/src/serialize.rs
+++ b/crates/protocol/src/serialize.rs
@@ -249,9 +249,10 @@ mod tests {
                     channel: "!1@localhost".into(),
                     max_clients: 100,
                     max_payload_size: 16,
+                    r#type: "pubsub".into(),
                     ..Default::default()
                 }),
-                expected_out: Some("CHAN_CONFIG id=1 channel=!1@localhost max_clients=100 max_payload_size=16 max_persist_messages=0 message_flush_interval=0 persist=false\n".to_string()),
+                expected_out: Some("CHAN_CONFIG id=1 channel=!1@localhost max_clients=100 max_payload_size=16 max_persist_messages=0 message_flush_interval=0 persist=false type=pubsub\n".to_string()),
             },
             TestCase {
                 name: "CONNECT",

--- a/crates/server/src/c2s/conn.rs
+++ b/crates/server/src/c2s/conn.rs
@@ -805,6 +805,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> C2sDispatcherInner<CS, MLF> {
     let mut channel_id: Option<ChannelId> = None;
 
     let mut channel_config = ChannelConfig::default();
+    let mut requested_type: Option<crate::channel::ChannelType> = None;
 
     if let Message::SetChannelConfiguration(params) = msg {
       correlation_id = params.id;
@@ -818,6 +819,21 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> C2sDispatcherInner<CS, MLF> {
         persist: params.persist,
         message_flush_interval: params.message_flush_interval,
       };
+
+      if let Some(type_atom) = params.r#type {
+        requested_type = Some(match type_atom.as_ref() {
+          "pubsub" => crate::channel::ChannelType::PubSub,
+          "fifo" => crate::channel::ChannelType::Fifo,
+          other => {
+            return Err(
+              narwhal_protocol::Error::new(BadRequest)
+                .with_id(correlation_id)
+                .with_detail(format!("unknown channel type: {other}"))
+                .into(),
+            );
+          },
+        });
+      }
     }
 
     if channel_config.persist == Some(true) && !self.auth_required {
@@ -834,7 +850,14 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> C2sDispatcherInner<CS, MLF> {
     // Submit the request to set the channel configuration.
     self
       .channel_manager
-      .set_channel_configuration(channel_config, channel_id.clone(), nid.clone(), transmitter, correlation_id)
+      .set_channel_configuration(
+        channel_config,
+        requested_type,
+        channel_id.clone(),
+        nid.clone(),
+        transmitter,
+        correlation_id,
+      )
       .await?;
 
     trace!(

--- a/crates/server/src/channel/fifo_cursor.rs
+++ b/crates/server/src/channel/fifo_cursor.rs
@@ -111,18 +111,6 @@ impl FifoCursor {
     self.next_seq = new_next_seq;
     Ok(())
   }
-
-  /// Removes `cursor.bin` from disk. Called by the DELETE machinery when
-  /// cleaning up a FIFO channel. NotFound is treated as success (matches
-  /// the existing pattern in `FileChannelStore::delete_channel`).
-  pub async fn delete(&self) -> anyhow::Result<()> {
-    let path = self.channel_dir.join(CURSOR_FILE);
-    match compio::fs::remove_file(&path).await {
-      Ok(()) => Ok(()),
-      Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-      Err(e) => Err(e.into()),
-    }
-  }
 }
 
 fn encode(next_seq: u64) -> Vec<u8> {
@@ -168,17 +156,6 @@ mod tests {
 
     let loaded = FifoCursor::load(tmp.path().to_path_buf(), 1, 5).await.unwrap();
     assert_eq!(loaded.next_seq(), 2);
-  }
-
-  #[compio::test]
-  async fn delete_removes_file() {
-    let tmp = tempfile::tempdir().unwrap();
-    let cursor = FifoCursor::write_initial(tmp.path().to_path_buf(), 3).await.unwrap();
-    assert!(tmp.path().join(CURSOR_FILE).exists());
-    cursor.delete().await.unwrap();
-    assert!(!tmp.path().join(CURSOR_FILE).exists());
-    // Idempotent.
-    cursor.delete().await.unwrap();
   }
 
   #[compio::test]

--- a/crates/server/src/channel/fifo_cursor.rs
+++ b/crates/server/src/channel/fifo_cursor.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! FIFO head cursor sidecar. The cursor records the next sequence number to
+//! be POPped from a FIFO channel and is fsynced to disk before each POP ACK
+//! so a crash mid-POP cannot resurrect already-delivered entries.
+//!
+//! On-disk layout (`<channel_dir>/cursor.bin`):
+//!
+//! ```text
+//! offset  size  field
+//! ------  ----  -----
+//! 0       8     next_seq      u64 little-endian
+//! 8       4     crc32         CRC-32/IEEE over bytes [0..8)
+//! 12      4     reserved      zero pad
+//! ```
+//!
+//! Total file size: 16 bytes. Writes go through `atomic_write` (tmp →
+//! fsync → rename → fsync parent) so a crash leaves either the previous
+//! durable cursor or the new one, never a half-written file.
+
+use std::path::PathBuf;
+
+use crate::util::file::{DirSync, atomic_write};
+
+/// Filename for the FIFO head cursor sidecar inside a channel directory.
+pub const CURSOR_FILE: &str = "cursor.bin";
+pub const CURSOR_TMP_FILE: &str = "cursor.bin.tmp";
+
+const CURSOR_FILE_SIZE: usize = 16;
+
+/// In-memory handle to a FIFO channel's head cursor on disk.
+#[derive(Debug)]
+pub struct FifoCursor {
+  next_seq: u64,
+  channel_dir: PathBuf,
+}
+
+impl FifoCursor {
+  /// Returns the next sequence number to be POPped.
+  #[allow(dead_code)] // used by PR 2 (POP path).
+  pub fn next_seq(&self) -> u64 {
+    self.next_seq
+  }
+
+  /// Atomically writes the initial cursor (called during pub/sub → FIFO
+  /// transition). Fsyncs the file and the parent directory so the cursor is
+  /// durable before the metadata save advertises the channel as FIFO.
+  pub async fn write_initial(channel_dir: PathBuf, next_seq: u64) -> anyhow::Result<Self> {
+    compio::fs::create_dir_all(&channel_dir).await?;
+    let bytes = encode(next_seq);
+    let final_path = channel_dir.join(CURSOR_FILE);
+    let tmp_path = channel_dir.join(CURSOR_TMP_FILE);
+    let (result, _) = atomic_write(&final_path, &tmp_path, bytes, DirSync::Strict).await;
+    result?;
+    Ok(Self { next_seq, channel_dir })
+  }
+
+  /// Loads the cursor from disk and cross-validates it against the log's
+  /// `first_seq` / `last_seq`. The five validation rules implemented here
+  /// match the spec at `docs/architecture/channels/fifo-channels.md`:
+  ///
+  /// 1. File exists and is the expected size.
+  /// 2. CRC32 over the encoded `next_seq` matches.
+  /// 3. `next_seq >= 1`.
+  /// 4. `next_seq <= log.last_seq() + 1`.
+  /// 5. If the queue is non-empty (`next_seq <= log.last_seq()`),
+  ///    `log.first_seq() <= next_seq`.
+  ///
+  /// Any failure is returned as an error and the caller surfaces the channel
+  /// as `NeedsRecovery` (FIFO data-plane ops then return
+  /// `CursorRecoveryRequired`).
+  pub async fn load(channel_dir: PathBuf, log_first_seq: u64, log_last_seq: u64) -> anyhow::Result<Self> {
+    let path = channel_dir.join(CURSOR_FILE);
+    let bytes = compio::fs::read(&path).await?;
+    if bytes.len() != CURSOR_FILE_SIZE {
+      return Err(anyhow::anyhow!("cursor.bin: unexpected size {}", bytes.len()));
+    }
+    let next_seq = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
+    let stored_crc = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+    let computed = crc32(&bytes[0..8]);
+    if stored_crc != computed {
+      return Err(anyhow::anyhow!("cursor.bin: crc32 mismatch (stored={stored_crc:x}, computed={computed:x})"));
+    }
+    if next_seq < 1 {
+      return Err(anyhow::anyhow!("cursor.bin: next_seq must be >= 1"));
+    }
+    if next_seq > log_last_seq.saturating_add(1) {
+      return Err(anyhow::anyhow!("cursor.bin: next_seq {next_seq} > log.last_seq + 1 ({log_last_seq})"));
+    }
+    let queue_non_empty = next_seq <= log_last_seq;
+    if queue_non_empty && log_first_seq > next_seq {
+      return Err(anyhow::anyhow!(
+        "cursor.bin: log.first_seq {log_first_seq} > next_seq {next_seq} (queue non-empty)"
+      ));
+    }
+
+    Ok(Self { next_seq, channel_dir })
+  }
+
+  /// Atomically rewrites the cursor with `next_seq + 1`. On success the
+  /// in-memory `next_seq` is advanced to match.
+  ///
+  /// Caller responsibility: only call after the corresponding entry has been
+  /// fsynced to the message log (`log.flush()` if not already durable).
+  #[allow(dead_code)] // used by PR 2 (POP path); kept for module symmetry.
+  pub async fn advance(&mut self) -> anyhow::Result<()> {
+    let new_next_seq = self.next_seq + 1;
+    let bytes = encode(new_next_seq);
+    let final_path = self.channel_dir.join(CURSOR_FILE);
+    let tmp_path = self.channel_dir.join(CURSOR_TMP_FILE);
+    let (result, _) = atomic_write(&final_path, &tmp_path, bytes, DirSync::Strict).await;
+    result?;
+    self.next_seq = new_next_seq;
+    Ok(())
+  }
+
+  /// Removes `cursor.bin` from disk. Called by the DELETE machinery when
+  /// cleaning up a FIFO channel. NotFound is treated as success (matches
+  /// the existing pattern in `FileChannelStore::delete_channel`).
+  pub async fn delete(&self) -> anyhow::Result<()> {
+    let path = self.channel_dir.join(CURSOR_FILE);
+    match compio::fs::remove_file(&path).await {
+      Ok(()) => Ok(()),
+      Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+      Err(e) => Err(e.into()),
+    }
+  }
+}
+
+fn encode(next_seq: u64) -> Vec<u8> {
+  let mut buf = vec![0u8; CURSOR_FILE_SIZE];
+  buf[0..8].copy_from_slice(&next_seq.to_le_bytes());
+  let crc = crc32(&buf[0..8]);
+  buf[8..12].copy_from_slice(&crc.to_le_bytes());
+  buf
+}
+
+fn crc32(data: &[u8]) -> u32 {
+  const POLY: u32 = 0xEDB88320;
+  let mut crc: u32 = 0xFFFF_FFFF;
+  for &b in data {
+    crc ^= u32::from(b);
+    for _ in 0..8 {
+      crc = if crc & 1 != 0 { (crc >> 1) ^ POLY } else { crc >> 1 };
+    }
+  }
+  !crc
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[compio::test]
+  async fn write_initial_then_load_round_trips() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cursor = FifoCursor::write_initial(tmp.path().to_path_buf(), 7).await.unwrap();
+    assert_eq!(cursor.next_seq(), 7);
+
+    let loaded = FifoCursor::load(tmp.path().to_path_buf(), 1, 7).await.unwrap();
+    assert_eq!(loaded.next_seq(), 7);
+  }
+
+  #[compio::test]
+  async fn advance_persists_new_seq() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut cursor = FifoCursor::write_initial(tmp.path().to_path_buf(), 1).await.unwrap();
+    cursor.advance().await.unwrap();
+    assert_eq!(cursor.next_seq(), 2);
+
+    let loaded = FifoCursor::load(tmp.path().to_path_buf(), 1, 5).await.unwrap();
+    assert_eq!(loaded.next_seq(), 2);
+  }
+
+  #[compio::test]
+  async fn delete_removes_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cursor = FifoCursor::write_initial(tmp.path().to_path_buf(), 3).await.unwrap();
+    assert!(tmp.path().join(CURSOR_FILE).exists());
+    cursor.delete().await.unwrap();
+    assert!(!tmp.path().join(CURSOR_FILE).exists());
+    // Idempotent.
+    cursor.delete().await.unwrap();
+  }
+
+  #[compio::test]
+  async fn load_missing_file_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(FifoCursor::load(tmp.path().to_path_buf(), 0, 0).await.is_err());
+  }
+
+  #[compio::test]
+  async fn load_bad_crc_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cursor_path = tmp.path().join(CURSOR_FILE);
+    let mut bytes = encode(5);
+    bytes[8] ^= 0xff;
+    std::fs::write(&cursor_path, &bytes).unwrap();
+    let err = FifoCursor::load(tmp.path().to_path_buf(), 1, 10).await.unwrap_err();
+    assert!(err.to_string().contains("crc32"), "{err}");
+  }
+
+  #[compio::test]
+  async fn load_zero_next_seq_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cursor_path = tmp.path().join(CURSOR_FILE);
+    std::fs::write(&cursor_path, encode(0)).unwrap();
+    let err = FifoCursor::load(tmp.path().to_path_buf(), 0, 0).await.unwrap_err();
+    assert!(err.to_string().contains(">= 1"), "{err}");
+  }
+
+  #[compio::test]
+  async fn load_next_seq_beyond_log_last_seq_plus_one_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cursor_path = tmp.path().join(CURSOR_FILE);
+    std::fs::write(&cursor_path, encode(10)).unwrap();
+    let err = FifoCursor::load(tmp.path().to_path_buf(), 1, 5).await.unwrap_err();
+    assert!(err.to_string().contains("> log.last_seq + 1"), "{err}");
+  }
+
+  #[compio::test]
+  async fn load_first_seq_above_next_seq_when_non_empty_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cursor_path = tmp.path().join(CURSOR_FILE);
+    // next_seq=3, log range [5..=10] → queue non-empty (3 <= 10) and
+    // first_seq=5 > next_seq=3, so the entry the cursor points at is
+    // already evicted: this is corruption.
+    std::fs::write(&cursor_path, encode(3)).unwrap();
+    let err = FifoCursor::load(tmp.path().to_path_buf(), 5, 10).await.unwrap_err();
+    assert!(err.to_string().contains("queue non-empty"), "{err}");
+  }
+}

--- a/crates/server/src/channel/fifo_cursor.rs
+++ b/crates/server/src/channel/fifo_cursor.rs
@@ -89,9 +89,7 @@ impl FifoCursor {
     }
     let queue_non_empty = next_seq <= log_last_seq;
     if queue_non_empty && log_first_seq > next_seq {
-      return Err(anyhow::anyhow!(
-        "cursor.bin: log.first_seq {log_first_seq} > next_seq {next_seq} (queue non-empty)"
-      ));
+      return Err(anyhow::anyhow!("cursor.bin: log.first_seq {log_first_seq} > next_seq {next_seq} (queue non-empty)"));
     }
 
     Ok(Self { next_seq, channel_dir })

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -19,7 +19,7 @@ use prometheus_client::metrics::histogram::Histogram;
 use prometheus_client::registry::Registry;
 
 use super::file_store::channel_hash;
-use super::store::{LogEntry, LogVisitor, MessageLog, MessageLogFactory};
+use super::store::{LogEntry, LogMode, LogVisitor, MessageLog, MessageLogFactory};
 
 /// Maximum segment file size before rolling to a new segment.
 const SEGMENT_MAX_BYTES: u64 = 128 * 1024 * 1024; // 128 MiB
@@ -337,6 +337,18 @@ struct Inner {
   /// Pre-allocated entry reader for the read path and recovery.
   reader: EntryReader,
 
+  /// Highest seq successfully fsynced via `flush`. 0 until the first flush.
+  /// Capped at `cached_last_seq` and updated only on flush success so that
+  /// callers can distinguish "appended but not yet fsynced" from "durable".
+  cached_durable_seq: u64,
+
+  /// Whether the log is operating in FIFO mode. In FIFO mode `append` does
+  /// **not** tail-evict on `max_messages`; eviction is driven by
+  /// `evict_below` from the manager. Toggled on at startup (when the
+  /// persisted `channel_type` is FIFO) or via `switch_to_fifo_mode` during
+  /// the in-runtime pub/sub → FIFO transition.
+  fifo_mode: bool,
+
   /// Metric handles for operations performed by the log.
   metrics: MessageLogMetrics,
 }
@@ -351,14 +363,11 @@ impl FileMessageLog {
   /// writes, the active `.idx` cannot be opened or memory-mapped). Callers
   /// should refuse to bring the affected channel online rather than continue
   /// with a half-initialized log that would silently drop index updates.
-  async fn open(channel_dir: PathBuf, max_payload_size: u32, metrics: MessageLogMetrics) -> anyhow::Result<Self> {
-    Self::open_with_segment_max(channel_dir, max_payload_size, SEGMENT_MAX_BYTES, metrics).await
-  }
-
   async fn open_with_segment_max(
     channel_dir: PathBuf,
     max_payload_size: u32,
     segment_max_bytes: u64,
+    fifo_mode: bool,
     metrics: MessageLogMetrics,
   ) -> anyhow::Result<Self> {
     let mut inner = Inner {
@@ -375,12 +384,18 @@ impl FileMessageLog {
       cached_last_seq: 0,
       write_buf: Vec::with_capacity(ENTRY_HEADER_SIZE + NID_MAX_LENGTH + max_payload_size as usize + CRC_SIZE),
       reader: EntryReader::new(max_payload_size, metrics.crc_failures.clone()),
+      cached_durable_seq: 0,
+      fifo_mode,
       metrics,
     };
     let start = Instant::now();
     let result = inner.recover().await;
     inner.metrics.recovery_duration_seconds.observe(start.elapsed().as_secs_f64());
     result?;
+    // Anything that survived recovery is on disk — and was either fsynced
+    // by a previous flush or made durable by the OS sync (in either case
+    // it is durable from this process's perspective).
+    inner.cached_durable_seq = inner.cached_last_seq;
     Ok(FileMessageLog { inner: RefCell::new(inner) })
   }
 
@@ -1098,8 +1113,11 @@ impl MessageLog for FileMessageLog {
       inner.roll_segment(seq + 1).await?;
     }
 
-    // Evict old segments if needed.
-    inner.evict_segments(max_messages).await;
+    // Evict old segments if needed. FIFO mode disables count-driven tail
+    // eviction; head-driven eviction runs from `evict_below` instead.
+    if !inner.fifo_mode {
+      inner.evict_segments(max_messages).await;
+    }
 
     Ok(())
   }
@@ -1150,6 +1168,9 @@ impl MessageLog for FileMessageLog {
       idx_file.sync_all().await?;
     }
 
+    // Both the data and index are durable past this point.
+    inner.cached_durable_seq = inner.cached_last_seq;
+
     Ok(())
   }
 
@@ -1159,6 +1180,44 @@ impl MessageLog for FileMessageLog {
 
   fn last_seq(&self) -> u64 {
     self.inner.borrow().cached_last_seq
+  }
+
+  fn last_durable_seq(&self) -> u64 {
+    self.inner.borrow().cached_durable_seq
+  }
+
+  fn switch_to_fifo_mode(&self) {
+    self.inner.borrow_mut().fifo_mode = true;
+  }
+
+  async fn evict_below(&self, seq: u64) -> anyhow::Result<()> {
+    let inner = &mut *self.inner.borrow_mut();
+    if !inner.fifo_mode || seq == 0 {
+      return Ok(());
+    }
+    // Drop sealed segments whose entire range sits below `seq`. Never
+    // evict the segment that contains `cached_last_seq` — it is the tail
+    // (active or last-rolled) segment and there must always be a place to
+    // append into. With `segments.len() > 1` we always preserve at least
+    // one segment.
+    while inner.segments.len() > 1 {
+      let head = &inner.segments[0];
+      if head.last_seq >= seq {
+        break;
+      }
+      let removed = inner.segments.remove(0);
+      let log_path = inner.segment_log_path(removed.first_seq);
+      let idx_path = inner.segment_idx_path(removed.first_seq);
+      let fallback_size = removed.file_size;
+      let physical_size = compio::fs::metadata(&log_path).await.map(|m| m.len()).unwrap_or(fallback_size);
+      inner.metrics.segments_evicted.inc();
+      inner.metrics.evicted_bytes.inc_by(physical_size);
+      drop(removed);
+      let _ = compio::fs::remove_file(log_path).await;
+      let _ = compio::fs::remove_file(idx_path).await;
+    }
+    inner.cached_first_seq = inner.segments.first().map_or(0, |s| s.first_seq);
+    Ok(())
   }
 
   async fn read(&self, from_seq: u64, limit: u32, visitor: &mut impl LogVisitor) -> anyhow::Result<u32>
@@ -1285,15 +1344,22 @@ impl FileMessageLogFactory {
 impl MessageLogFactory for FileMessageLogFactory {
   type Log = FileMessageLog;
 
-  async fn create(&self, handler: &StringAtom) -> anyhow::Result<FileMessageLog> {
+  async fn create(&self, handler: &StringAtom, mode: LogMode) -> anyhow::Result<FileMessageLog> {
+    let channel_dir = self.channel_dir_for(handler);
+    let fifo_mode = matches!(mode, LogMode::Fifo);
+    let segment_max = self.segment_max_bytes.unwrap_or(SEGMENT_MAX_BYTES);
+    FileMessageLog::open_with_segment_max(channel_dir, self.max_payload_size, segment_max, fifo_mode, self.metrics.clone()).await
+  }
+
+  fn channel_dir(&self, handler: &StringAtom) -> Option<PathBuf> {
+    Some(self.channel_dir_for(handler))
+  }
+}
+
+impl FileMessageLogFactory {
+  fn channel_dir_for(&self, handler: &StringAtom) -> PathBuf {
     let hash = channel_hash(handler);
-    let channel_dir = self.data_dir.join(hash.as_ref());
-    match self.segment_max_bytes {
-      Some(max) => {
-        FileMessageLog::open_with_segment_max(channel_dir, self.max_payload_size, max, self.metrics.clone()).await
-      },
-      None => FileMessageLog::open(channel_dir, self.max_payload_size, self.metrics.clone()).await,
-    }
+    self.data_dir.join(hash.as_ref())
   }
 }
 
@@ -1362,7 +1428,7 @@ mod tests {
   /// Helper: create a FileMessageLog in a temp directory.
   async fn create_log(dir: &std::path::Path) -> FileMessageLog {
     let factory = FileMessageLogFactory::new(dir.to_path_buf(), TEST_MAX_PAYLOAD_SIZE, MessageLogMetrics::noop());
-    factory.create(&StringAtom::from("test_channel")).await.expect("recovery should succeed in tests")
+    factory.create(&StringAtom::from("test_channel"), LogMode::PubSub).await.expect("recovery should succeed in tests")
   }
 
   /// Helper: create a FileMessageLog with a custom segment size threshold.
@@ -1379,7 +1445,7 @@ mod tests {
   ) -> FileMessageLog {
     let hash = channel_hash(&StringAtom::from("test_channel"));
     let channel_dir = dir.join(hash.as_ref());
-    FileMessageLog::open_with_segment_max(channel_dir, TEST_MAX_PAYLOAD_SIZE, segment_max_bytes, metrics)
+    FileMessageLog::open_with_segment_max(channel_dir, TEST_MAX_PAYLOAD_SIZE, segment_max_bytes, false, metrics)
       .await
       .expect("recovery should succeed in tests")
   }
@@ -2498,8 +2564,8 @@ mod tests {
     let factory =
       FileMessageLogFactory::new(tmp.path().to_path_buf(), TEST_MAX_PAYLOAD_SIZE, MessageLogMetrics::noop());
 
-    let log_a = factory.create(&StringAtom::from("channel_a")).await.unwrap();
-    let log_b = factory.create(&StringAtom::from("channel_b")).await.unwrap();
+    let log_a = factory.create(&StringAtom::from("channel_a"), LogMode::PubSub).await.unwrap();
+    let log_b = factory.create(&StringAtom::from("channel_b"), LogMode::PubSub).await.unwrap();
 
     append_message(&log_a, 1, "alice@localhost", b"for_a", 100).await;
     append_message(&log_b, 1, "bob@localhost", b"for_b", 100).await;
@@ -2515,5 +2581,98 @@ mod tests {
     log_b.read(1, 10, &mut visitor_b).await.unwrap();
     assert_eq!(visitor_b.entries[0].from, "bob@localhost");
     assert_eq!(visitor_b.entries[0].payload, b"for_b");
+  }
+
+  // ===== FIFO mode + new MessageLog API =====
+
+  #[compio::test]
+  async fn test_last_durable_seq_lags_until_flush() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = create_log(tmp.path()).await;
+
+    assert_eq!(log.last_durable_seq(), 0);
+
+    append_message(&log, 1, "alice@localhost", b"a", 0).await;
+    assert_eq!(log.last_seq(), 1);
+    assert_eq!(log.last_durable_seq(), 0, "appended but not yet flushed");
+
+    log.flush().await.unwrap();
+    assert_eq!(log.last_durable_seq(), 1, "flushed → durable matches last_seq");
+
+    append_message(&log, 2, "alice@localhost", b"b", 0).await;
+    assert_eq!(log.last_durable_seq(), 1, "second append, no flush yet");
+
+    log.flush().await.unwrap();
+    assert_eq!(log.last_durable_seq(), 2);
+  }
+
+  #[compio::test]
+  async fn test_switch_to_fifo_mode_disables_tail_eviction() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = create_log(tmp.path()).await;
+
+    log.switch_to_fifo_mode();
+
+    // max_messages=1 in pub/sub mode would evict everything but the latest;
+    // in FIFO mode it must be a no-op. We verify by checking that all five
+    // entries are still readable.
+    for seq in 1..=5 {
+      append_message(&log, seq, "alice@localhost", b"x", 1).await;
+    }
+    log.flush().await.unwrap();
+
+    let mut visitor = CollectingVisitor::new();
+    log.read(1, 10, &mut visitor).await.unwrap();
+    let seqs: Vec<u64> = visitor.entries.iter().map(|e| e.seq).collect();
+    assert_eq!(seqs, vec![1, 2, 3, 4, 5]);
+  }
+
+  #[compio::test]
+  async fn test_evict_below_drops_sealed_segments_with_tail_retention() {
+    // Use a small segment threshold so each entry rolls a new segment.
+    let tmp = tempfile::tempdir().unwrap();
+    let log = create_log_with_segment_max(tmp.path(), 1).await;
+    log.switch_to_fifo_mode();
+
+    for seq in 1..=4 {
+      append_message(&log, seq, "alice@localhost", b"payload", 0).await;
+    }
+    log.flush().await.unwrap();
+
+    // Should now have multiple segments. evict_below(3) drops segments
+    // whose last_seq < 3. The active (last) segment is retained even if
+    // its last_seq < 3 (tail-segment retention).
+    log.evict_below(3).await.unwrap();
+    assert!(log.first_seq() <= 3, "first_seq after evict_below(3): {}", log.first_seq());
+    assert_eq!(log.last_seq(), 4, "tail segment must remain");
+  }
+
+  #[compio::test]
+  async fn test_evict_below_no_op_in_pubsub_mode() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = create_log_with_segment_max(tmp.path(), 1).await;
+
+    for seq in 1..=4 {
+      append_message(&log, seq, "alice@localhost", b"payload", 0).await;
+    }
+    log.flush().await.unwrap();
+
+    let first_before = log.first_seq();
+    log.evict_below(3).await.unwrap();
+    assert_eq!(log.first_seq(), first_before, "evict_below must not affect pub/sub mode");
+  }
+
+  #[compio::test]
+  async fn test_evict_below_zero_is_no_op() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = create_log_with_segment_max(tmp.path(), 1).await;
+    log.switch_to_fifo_mode();
+    for seq in 1..=3 {
+      append_message(&log, seq, "alice@localhost", b"x", 0).await;
+    }
+    log.flush().await.unwrap();
+    let first_before = log.first_seq();
+    log.evict_below(0).await.unwrap();
+    assert_eq!(log.first_seq(), first_before);
   }
 }

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -1348,7 +1348,14 @@ impl MessageLogFactory for FileMessageLogFactory {
     let channel_dir = self.channel_dir_for(handler);
     let fifo_mode = matches!(mode, LogMode::Fifo);
     let segment_max = self.segment_max_bytes.unwrap_or(SEGMENT_MAX_BYTES);
-    FileMessageLog::open_with_segment_max(channel_dir, self.max_payload_size, segment_max, fifo_mode, self.metrics.clone()).await
+    FileMessageLog::open_with_segment_max(
+      channel_dir,
+      self.max_payload_size,
+      segment_max,
+      fifo_mode,
+      self.metrics.clone(),
+    )
+    .await
   }
 
   fn channel_dir(&self, handler: &StringAtom) -> Option<PathBuf> {

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -1196,23 +1196,25 @@ impl MessageLog for FileMessageLog {
       return Ok(());
     }
     // Drop sealed segments whose entire range sits below `seq`. Never
-    // evict the segment that contains `cached_last_seq` — it is the tail
-    // (active or last-rolled) segment and there must always be a place to
-    // append into. With `segments.len() > 1` we always preserve at least
-    // one segment.
-    while inner.segments.len() > 1 {
-      let head = &inner.segments[0];
-      if head.last_seq >= seq {
-        break;
-      }
-      let removed = inner.segments.remove(0);
-      let log_path = inner.segment_log_path(removed.first_seq);
-      let idx_path = inner.segment_idx_path(removed.first_seq);
-      let fallback_size = removed.file_size;
+    // evict the segment that contains `cached_last_seq` (the tail-segment
+    // retention invariant: there must always be a place to append into),
+    // so the eviction count is capped at `segments.len() - 1`.
+    //
+    // Compute the cutoff once and `drain(..cutoff)` so the remaining tail
+    // shifts a single time, instead of O(n) per removed segment with
+    // `Vec::remove(0)` in a loop.
+    let max_evict = inner.segments.len().saturating_sub(1);
+    let cutoff = inner.segments.iter().take(max_evict).position(|s| s.last_seq >= seq).unwrap_or(max_evict);
+
+    let removed: Vec<SegmentInfo> = inner.segments.drain(..cutoff).collect();
+    for r in removed {
+      let log_path = inner.segment_log_path(r.first_seq);
+      let idx_path = inner.segment_idx_path(r.first_seq);
+      let fallback_size = r.file_size;
       let physical_size = compio::fs::metadata(&log_path).await.map(|m| m.len()).unwrap_or(fallback_size);
       inner.metrics.segments_evicted.inc();
       inner.metrics.evicted_bytes.inc_by(physical_size);
-      drop(removed);
+      drop(r);
       let _ = compio::fs::remove_file(log_path).await;
       let _ = compio::fs::remove_file(idx_path).await;
     }

--- a/crates/server/src/channel/file_message_log.rs
+++ b/crates/server/src/channel/file_message_log.rs
@@ -392,10 +392,13 @@ impl FileMessageLog {
     let result = inner.recover().await;
     inner.metrics.recovery_duration_seconds.observe(start.elapsed().as_secs_f64());
     result?;
-    // Anything that survived recovery is on disk — and was either fsynced
-    // by a previous flush or made durable by the OS sync (in either case
-    // it is durable from this process's perspective).
-    inner.cached_durable_seq = inner.cached_last_seq;
+    // Leave `cached_durable_seq` at 0 after recovery. Recovered entries
+    // are readable from the file but were not fsynced by *this* process,
+    // and the trait contract says "highest seq fsynced via flush".
+    // Sticking to the contract means the first FIFO POP after restart
+    // forces a flush before advancing the cursor, closing a window where
+    // a fresh power loss could lose data while the cursor sidecar said
+    // it had already been consumed.
     Ok(FileMessageLog { inner: RefCell::new(inner) })
   }
 
@@ -2613,6 +2616,26 @@ mod tests {
 
     log.flush().await.unwrap();
     assert_eq!(log.last_durable_seq(), 2);
+  }
+
+  #[compio::test]
+  async fn test_last_durable_seq_resets_to_zero_after_reopen() {
+    let tmp = tempfile::tempdir().unwrap();
+    {
+      let log = create_log(tmp.path()).await;
+      append_message(&log, 1, "alice@localhost", b"a", 0).await;
+      log.flush().await.unwrap();
+      assert_eq!(log.last_durable_seq(), 1);
+    }
+
+    // Reopen on the same directory: the entry is recoverable, but
+    // durability hasn't been re-established by *this* process.
+    let log = create_log(tmp.path()).await;
+    assert_eq!(log.last_seq(), 1, "entry must survive recovery");
+    assert_eq!(log.last_durable_seq(), 0, "durable seq stays at 0 until first flush in this process");
+
+    log.flush().await.unwrap();
+    assert_eq!(log.last_durable_seq(), 1);
   }
 
   #[compio::test]

--- a/crates/server/src/channel/file_store.rs
+++ b/crates/server/src/channel/file_store.rs
@@ -8,7 +8,7 @@ use sha2::{Digest, Sha256};
 
 use narwhal_util::string_atom::StringAtom;
 
-use super::store::{ChannelStore, PersistedChannel, decode_persisted_channel};
+use super::store::{ChannelStore, PersistedChannel};
 use crate::util::file::{DirSync, atomic_write};
 
 const METADATA_FILE: &str = "metadata.bin";
@@ -145,7 +145,7 @@ impl ChannelStore for FileChannelStore {
       return Err(anyhow::anyhow!("metadata file exceeds {} bytes", MAX_METADATA_SIZE));
     }
     let data = compio::fs::read(&path).await?;
-    let channel = decode_persisted_channel(&data)?;
+    let channel = postcard::from_bytes(&data)?;
     Ok(channel)
   }
 }
@@ -288,45 +288,6 @@ mod tests {
 
     let result = store.load_channel(&hash).await;
     assert!(result.is_err());
-  }
-
-  #[compio::test]
-  async fn test_load_legacy_metadata_decodes_as_pubsub() {
-    // Simulates the on-disk shape produced by a build that predates the FIFO
-    // slice: `metadata.bin` is missing the trailing `channel_type` field.
-    // `load_channel` must fall back to the legacy schema and tag the result
-    // as `PubSub` so the channel survives the upgrade.
-    use crate::channel::store::LegacyPersistedChannel;
-
-    let tmp = tempfile::tempdir().unwrap();
-    let store = FileChannelStore::new(tmp.path().to_path_buf()).await.unwrap();
-
-    let handler = StringAtom::from("legacy_channel");
-    let legacy = LegacyPersistedChannel {
-      handler: handler.clone(),
-      owner: Some(Nid::new_unchecked(StringAtom::from("alice"), StringAtom::from("localhost"))),
-      config: ChannelConfig {
-        persist: Some(true),
-        max_clients: Some(50),
-        max_payload_size: Some(1024),
-        max_persist_messages: Some(100),
-        message_flush_interval: Some(0),
-      },
-      acl: ChannelAcl::default(),
-      members: vec![Nid::new_unchecked(StringAtom::from("alice"), StringAtom::from("localhost"))],
-    };
-    let bytes = postcard::to_allocvec(&legacy).unwrap();
-
-    let hash = channel_hash(&handler);
-    let dir = tmp.path().join(hash.as_ref());
-    std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(dir.join(METADATA_FILE), bytes).unwrap();
-
-    let loaded = store.load_channel(&hash).await.unwrap();
-    assert_eq!(loaded.handler, handler);
-    assert_eq!(loaded.channel_type, ChannelType::PubSub);
-    assert_eq!(loaded.config.persist, Some(true));
-    assert_eq!(loaded.members.len(), 1);
   }
 
   #[compio::test]

--- a/crates/server/src/channel/file_store.rs
+++ b/crates/server/src/channel/file_store.rs
@@ -74,8 +74,21 @@ impl ChannelStore for FileChannelStore {
       Err(e) => return Err(e.into()),
     };
     for entry in entries {
-      let entry = entry?;
-      if entry.file_type()?.is_file()
+      // Files can disappear between `read_dir`'s snapshot and the per-entry
+      // stat/unlink (parallel deletes, concurrent admin tooling, etc.). Any
+      // NotFound mid-loop is consistent with our idempotent contract and is
+      // skipped instead of propagated.
+      let entry = match entry {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+        Err(e) => return Err(e.into()),
+      };
+      let file_type = match entry.file_type() {
+        Ok(ft) => ft,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+        Err(e) => return Err(e.into()),
+      };
+      if file_type.is_file()
         && let Err(e) = compio::fs::remove_file(entry.path()).await
         && e.kind() != std::io::ErrorKind::NotFound
       {

--- a/crates/server/src/channel/file_store.rs
+++ b/crates/server/src/channel/file_store.rs
@@ -61,18 +61,26 @@ impl ChannelStore for FileChannelStore {
 
   async fn delete_channel(&self, hash: &StringAtom) -> anyhow::Result<()> {
     let dir = self.channel_dir(hash.as_ref());
-    // Remove metadata files, then the directory. Treat NotFound as success.
-    let metadata_path = dir.join(METADATA_FILE);
-    if let Err(e) = compio::fs::remove_file(&metadata_path).await
-      && e.kind() != std::io::ErrorKind::NotFound
-    {
-      return Err(e.into());
-    }
-    let tmp_path = dir.join(METADATA_TMP_FILE);
-    if let Err(e) = compio::fs::remove_file(&tmp_path).await
-      && e.kind() != std::io::ErrorKind::NotFound
-    {
-      return Err(e.into());
+    // Remove every file in the channel directory before removing the
+    // directory itself. The dir may contain `metadata.bin`, an in-flight
+    // `metadata.bin.tmp`, the FIFO `cursor.bin`/`cursor.bin.tmp`
+    // sidecars, or any future per-channel artifact: the store contract
+    // is "delete = wipe everything", so a partial cleanup leaves the
+    // directory non-empty and `remove_dir` would fail. NotFound at any
+    // step is treated as success (idempotent delete).
+    let entries = match std::fs::read_dir(&dir) {
+      Ok(entries) => entries,
+      Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+      Err(e) => return Err(e.into()),
+    };
+    for entry in entries {
+      let entry = entry?;
+      if entry.file_type()?.is_file()
+        && let Err(e) = compio::fs::remove_file(entry.path()).await
+        && e.kind() != std::io::ErrorKind::NotFound
+      {
+        return Err(e.into());
+      }
     }
     if let Err(e) = compio::fs::remove_dir(&dir).await
       && e.kind() != std::io::ErrorKind::NotFound
@@ -207,6 +215,26 @@ mod tests {
 
     let hashes = store.load_channel_hashes().await.unwrap();
     assert_eq!(hashes.len(), 0);
+  }
+
+  #[compio::test]
+  async fn test_delete_channel_wipes_unknown_sidecars() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = FileChannelStore::new(tmp.path().to_path_buf()).await.unwrap();
+
+    // Save a channel so the directory exists with metadata.bin.
+    store.save_channel(&test_channel("withcursor")).await.unwrap();
+    let hash = channel_hash(&StringAtom::from("withcursor"));
+    let dir = tmp.path().join(hash.as_ref());
+
+    // Stand in for a FIFO cursor sidecar plus an arbitrary unknown file
+    // that some future feature might add.
+    std::fs::write(dir.join("cursor.bin"), b"\x00").unwrap();
+    std::fs::write(dir.join("future_artifact.bin"), b"\x00").unwrap();
+
+    store.delete_channel(&hash).await.unwrap();
+
+    assert!(!dir.exists(), "channel directory should be fully removed even with unknown files");
   }
 
   #[compio::test]

--- a/crates/server/src/channel/file_store.rs
+++ b/crates/server/src/channel/file_store.rs
@@ -8,7 +8,7 @@ use sha2::{Digest, Sha256};
 
 use narwhal_util::string_atom::StringAtom;
 
-use super::store::{ChannelStore, PersistedChannel};
+use super::store::{ChannelStore, PersistedChannel, decode_persisted_channel};
 use crate::util::file::{DirSync, atomic_write};
 
 const METADATA_FILE: &str = "metadata.bin";
@@ -145,7 +145,7 @@ impl ChannelStore for FileChannelStore {
       return Err(anyhow::anyhow!("metadata file exceeds {} bytes", MAX_METADATA_SIZE));
     }
     let data = compio::fs::read(&path).await?;
-    let channel = postcard::from_bytes(&data)?;
+    let channel = decode_persisted_channel(&data)?;
     Ok(channel)
   }
 }
@@ -288,6 +288,45 @@ mod tests {
 
     let result = store.load_channel(&hash).await;
     assert!(result.is_err());
+  }
+
+  #[compio::test]
+  async fn test_load_legacy_metadata_decodes_as_pubsub() {
+    // Simulates the on-disk shape produced by a build that predates the FIFO
+    // slice: `metadata.bin` is missing the trailing `channel_type` field.
+    // `load_channel` must fall back to the legacy schema and tag the result
+    // as `PubSub` so the channel survives the upgrade.
+    use crate::channel::store::LegacyPersistedChannel;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let store = FileChannelStore::new(tmp.path().to_path_buf()).await.unwrap();
+
+    let handler = StringAtom::from("legacy_channel");
+    let legacy = LegacyPersistedChannel {
+      handler: handler.clone(),
+      owner: Some(Nid::new_unchecked(StringAtom::from("alice"), StringAtom::from("localhost"))),
+      config: ChannelConfig {
+        persist: Some(true),
+        max_clients: Some(50),
+        max_payload_size: Some(1024),
+        max_persist_messages: Some(100),
+        message_flush_interval: Some(0),
+      },
+      acl: ChannelAcl::default(),
+      members: vec![Nid::new_unchecked(StringAtom::from("alice"), StringAtom::from("localhost"))],
+    };
+    let bytes = postcard::to_allocvec(&legacy).unwrap();
+
+    let hash = channel_hash(&handler);
+    let dir = tmp.path().join(hash.as_ref());
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(METADATA_FILE), bytes).unwrap();
+
+    let loaded = store.load_channel(&hash).await.unwrap();
+    assert_eq!(loaded.handler, handler);
+    assert_eq!(loaded.channel_type, ChannelType::PubSub);
+    assert_eq!(loaded.config.persist, Some(true));
+    assert_eq!(loaded.members.len(), 1);
   }
 
   #[compio::test]

--- a/crates/server/src/channel/file_store.rs
+++ b/crates/server/src/channel/file_store.rs
@@ -137,6 +137,7 @@ mod tests {
   use narwhal_util::string_atom::StringAtom;
 
   use super::*;
+  use crate::channel::store::ChannelType;
   use crate::channel::{ChannelAcl, ChannelConfig};
 
   fn test_channel(handler: &str) -> PersistedChannel {
@@ -155,6 +156,7 @@ mod tests {
         Nid::new_unchecked(StringAtom::from("alice"), StringAtom::from("localhost")),
         Nid::new_unchecked(StringAtom::from("bob"), StringAtom::from("localhost")),
       ]),
+      channel_type: ChannelType::PubSub,
     }
   }
 

--- a/crates/server/src/channel/manager.rs
+++ b/crates/server/src/channel/manager.rs
@@ -965,7 +965,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
 
     let owner_leaving_fifo = {
       let channel = self.channels.get(&channel_id.handler).unwrap();
-      matches!(channel.kind, ChannelKind::Fifo(_)) && channel.is_owner(&left_member_nid)
+      matches!(&channel.kind, ChannelKind::Fifo(_)) && channel.is_owner(&left_member_nid)
     };
     if owner_leaving_fifo {
       let Some(tx) = transmitter else {
@@ -1131,7 +1131,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       return Err(narwhal_protocol::Error::new(ChannelNotFound).with_id(correlation_id).into());
     };
 
-    if matches!(channel.kind, ChannelKind::Fifo(_)) {
+    if matches!(&channel.kind, ChannelKind::Fifo(_)) {
       return Err(narwhal_protocol::Error::new(WrongType).with_id(correlation_id).into());
     }
 
@@ -1695,7 +1695,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       return Err(narwhal_protocol::Error::new(ChannelNotFound).with_id(correlation_id).into());
     };
 
-    if matches!(channel.kind, ChannelKind::Fifo(_)) {
+    if matches!(&channel.kind, ChannelKind::Fifo(_)) {
       return Err(narwhal_protocol::Error::new(WrongType).with_id(correlation_id).into());
     }
 
@@ -1749,7 +1749,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       return Err(narwhal_protocol::Error::new(ChannelNotFound).with_id(correlation_id).into());
     };
 
-    if matches!(channel.kind, ChannelKind::Fifo(_)) {
+    if matches!(&channel.kind, ChannelKind::Fifo(_)) {
       return Err(narwhal_protocol::Error::new(WrongType).with_id(correlation_id).into());
     }
 

--- a/crates/server/src/channel/manager.rs
+++ b/crates/server/src/channel/manager.rs
@@ -1077,9 +1077,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
     let mut fifo_cursor_to_delete: Option<FifoCursor> = None;
     if let Some(channel) = self.channels.get_mut(&channel_id.handler) {
       channel.cancel_flush_task();
-      if let ChannelKind::Fifo(FifoState::Healthy(cursor)) =
-        std::mem::replace(&mut channel.kind, ChannelKind::PubSub)
-      {
+      if let ChannelKind::Fifo(FifoState::Healthy(cursor)) = std::mem::replace(&mut channel.kind, ChannelKind::PubSub) {
         fifo_cursor_to_delete = Some(cursor);
       }
       if is_persistent {

--- a/crates/server/src/channel/manager.rs
+++ b/crates/server/src/channel/manager.rs
@@ -1052,7 +1052,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
   /// Runs the full delete-channel machinery: notify members, release
   /// membership slots, cancel flush task, final flush, drop persistent
   /// storage (including the FIFO cursor sidecar), and remove the
-  /// in-memory channel. Does **not** send the request ack — callers do
+  /// in-memory channel. Does **not** send the request ack; callers do
   /// that based on which command initiated the delete (DELETE_ACK,
   /// LEAVE_ACK, etc.).
   async fn do_delete_channel(
@@ -1505,7 +1505,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
           // Cursor is stranded on disk. `load_channel_hashes` cleans up
           // directories whose metadata.bin is absent on next restart, and
           // the next successful retry of this same transition will
-          // overwrite it. No in-memory state changed yet — leave the
+          // overwrite it. No in-memory state changed yet, so leave the
           // channel as pub/sub and surface the error.
           return Err(e);
         },

--- a/crates/server/src/channel/manager.rs
+++ b/crates/server/src/channel/manager.rs
@@ -333,7 +333,10 @@ enum Command {
 /// FIFO-side state that is *not* persisted (e.g. the head cursor handle).
 pub(crate) enum ChannelKind {
   PubSub,
-  Fifo(FifoState),
+  // The `FifoState` payload is constructed by restore/transition and is
+  // read by the PR 2 data plane (PUSH/POP/GET_CHAN_LEN); PR 1 only
+  // discriminates the variant.
+  Fifo(#[allow(dead_code)] FifoState),
 }
 
 /// FIFO runtime state. `Healthy` carries an open cursor; `NeedsRecovery` is
@@ -341,7 +344,8 @@ pub(crate) enum ChannelKind {
 /// cursor recovery (PUSH/POP/GET_CHAN_LEN return `CursorRecoveryRequired`
 /// while DELETE/JOIN/LEAVE-non-owner/etc still work).
 pub(crate) enum FifoState {
-  Healthy(super::fifo_cursor::FifoCursor),
+  // Cursor is unused in PR 1; PR 2's POP path reads and advances it.
+  Healthy(#[allow(dead_code)] super::fifo_cursor::FifoCursor),
   NeedsRecovery,
 }
 
@@ -1069,17 +1073,13 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       self.membership.release_slot(username, &channel_id.handler).await;
     }
 
-    // Cancel flush task and perform final flush before cleanup. Capture
-    // the FIFO cursor (if any) up front so we can delete its sidecar
-    // outside the &mut channel borrow once `delete_persistent_storage`
-    // takes the channel mutably.
+    // Cancel flush task and perform final flush before cleanup. The
+    // FIFO cursor sidecar (if any) is wiped by `store.delete_channel`
+    // along with everything else in the channel directory, so the
+    // manager does not need a separate cursor.delete() step.
     let is_persistent = self.channels.get(&channel_id.handler).is_some_and(|c| c.config.persist == Some(true));
-    let mut fifo_cursor_to_delete: Option<FifoCursor> = None;
     if let Some(channel) = self.channels.get_mut(&channel_id.handler) {
       channel.cancel_flush_task();
-      if let ChannelKind::Fifo(FifoState::Healthy(cursor)) = std::mem::replace(&mut channel.kind, ChannelKind::PubSub) {
-        fifo_cursor_to_delete = Some(cursor);
-      }
       if is_persistent {
         let start = Instant::now();
         let result = channel.message_log.flush().await;
@@ -1088,16 +1088,6 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
           warn!(channel = %channel_id.handler, error = %e, "final flush on delete failed");
         }
       }
-    }
-
-    // Best-effort cursor sidecar removal. Errors here would only matter
-    // if the channel directory itself stays around for some reason; the
-    // store cleanup below removes the directory, so a stranded cursor
-    // bin is harmless beyond the immediate failure log.
-    if let Some(cursor) = fifo_cursor_to_delete
-      && let Err(e) = cursor.delete().await
-    {
-      warn!(channel = %channel_id.handler, error = %e, "failed to remove FIFO cursor sidecar");
     }
 
     // Clean up persistent storage. Best effort, must not block channel removal or leak slots.

--- a/crates/server/src/channel/manager.rs
+++ b/crates/server/src/channel/manager.rs
@@ -1517,6 +1517,21 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       channel.kind = ChannelKind::Fifo(FifoState::Healthy(cursor));
       channel.config = new_config.clone();
 
+      // Reconcile the periodic flush task against the new interval. FIFO is
+      // always persistent so the persistence-toggle branch is a no-op here,
+      // but a `flush_interval_changed` request still needs the cancel +
+      // optional restart logic that the non-transition path runs below.
+      Self::reconcile_flush_task_after_config_change(
+        channel,
+        &channel_id.handler,
+        false,
+        flush_interval_changed,
+        true,
+        &self.metrics,
+        self.mailbox_tx.clone(),
+      )
+      .await;
+
       // Steps 6/7: emit reconfigured event + ack.
       Self::emit_channel_reconfigured(channel, &channel_id, transmitter.clone(), self.local_domain.clone()).await;
       transmitter
@@ -1546,27 +1561,16 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
 
     channel.config = new_config;
 
-    // Cancel the flush task if persist was toggled off or flush interval changed.
-    if (!is_persistent && was_persistent) || flush_interval_changed {
-      channel.cancel_flush_task();
-
-      // When the flush interval changed but persistence is still enabled, flush any buffered
-      // messages and restart the periodic task immediately so they are not left pending
-      // indefinitely waiting for the next broadcast.
-      if flush_interval_changed && is_persistent {
-        let start = Instant::now();
-        let result = channel.message_log.flush().await;
-        self.metrics.record_flush(start, &result);
-        if let Err(e) = result {
-          warn!(channel = %channel_id.handler, error = %e, "flush on interval change failed");
-        }
-        if let Some(interval) = channel.config.message_flush_interval
-          && interval > 0
-        {
-          channel.ensure_flush_task(interval, self.mailbox_tx.clone());
-        }
-      }
-    }
+    Self::reconcile_flush_task_after_config_change(
+      channel,
+      &channel_id.handler,
+      !is_persistent && was_persistent,
+      flush_interval_changed,
+      is_persistent,
+      &self.metrics,
+      self.mailbox_tx.clone(),
+    )
+    .await;
 
     if !is_persistent && was_persistent {
       self.delete_persistent_storage(&channel_id.handler).await;
@@ -1583,6 +1587,47 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       .send_message(Message::SetChannelConfigurationAck(SetChannelConfigurationAckParameters { id: correlation_id }));
 
     Ok(())
+  }
+
+  /// Reconciles the per-channel periodic flush task with the post-change
+  /// config. Used by both the FIFO transition and non-transition branches of
+  /// `set_channel_configuration` so that toggling persistence or changing
+  /// `message_flush_interval` always cancels the running task and restarts
+  /// a new one when the new interval is non-zero and the channel is still
+  /// persistent.
+  ///
+  /// `channel.config` must already reflect the new configuration when this
+  /// is called.
+  async fn reconcile_flush_task_after_config_change(
+    channel: &mut Channel<MLF::Log>,
+    channel_handler: &StringAtom,
+    persistence_disabled: bool,
+    flush_interval_changed: bool,
+    is_persistent: bool,
+    metrics: &ChannelManagerMetrics,
+    mailbox_tx: Sender<Command>,
+  ) {
+    if !(persistence_disabled || flush_interval_changed) {
+      return;
+    }
+    channel.cancel_flush_task();
+
+    // When the flush interval changed but persistence is still enabled, flush any buffered
+    // messages and restart the periodic task immediately so they are not left pending
+    // indefinitely waiting for the next broadcast.
+    if flush_interval_changed && is_persistent {
+      let start = Instant::now();
+      let result = channel.message_log.flush().await;
+      metrics.record_flush(start, &result);
+      if let Err(e) = result {
+        warn!(channel = %channel_handler, error = %e, "flush on interval change failed");
+      }
+      if let Some(interval) = channel.config.message_flush_interval
+        && interval > 0
+      {
+        channel.ensure_flush_task(interval, mailbox_tx);
+      }
+    }
   }
 
   /// Notifies all members of a successful CHAN_CONFIG change. The event

--- a/crates/server/src/channel/manager.rs
+++ b/crates/server/src/channel/manager.rs
@@ -14,6 +14,7 @@ use narwhal_common::core_dispatcher::CoreDispatcher;
 use narwhal_protocol::ErrorReason::{
   BadRequest, ChannelIsFull, ChannelNotFound, Forbidden, InternalServerError, NotAllowed, NotImplemented,
   PersistenceNotEnabled, PolicyViolation, ResourceLimitReached, UserInChannel, UserNotInChannel, UserNotRegistered,
+  WrongType,
 };
 use narwhal_protocol::{
   AclAction, AclType, BroadcastAckParameters, ChannelAclParameters, ChannelConfigurationParameters,
@@ -39,8 +40,11 @@ use crate::notifier::Notifier;
 use crate::router::GlobalRouter;
 use crate::transmitter::{Resource, Transmitter};
 
+use super::fifo_cursor::FifoCursor;
 use super::membership::Membership;
-use super::store::{ChannelStore, LogEntry, LogVisitor, MessageLog, MessageLogFactory, PersistedChannel};
+use super::store::{
+  ChannelStore, ChannelType, LogEntry, LogMode, LogVisitor, MessageLog, MessageLogFactory, PersistedChannel,
+};
 
 const DEFAULT_MAILBOX_CAPACITY: usize = 16384;
 
@@ -278,6 +282,7 @@ enum Command {
   },
   SetChannelConfiguration {
     config: ChannelConfig,
+    requested_type: Option<ChannelType>,
     channel_id: ChannelId,
     nid: Nid,
     transmitter: Arc<dyn Transmitter>,
@@ -324,6 +329,22 @@ enum Command {
   },
 }
 
+/// In-memory channel kind. Mirrors `store::ChannelType` but carries the
+/// FIFO-side state that is *not* persisted (e.g. the head cursor handle).
+pub(crate) enum ChannelKind {
+  PubSub,
+  Fifo(FifoState),
+}
+
+/// FIFO runtime state. `Healthy` carries an open cursor; `NeedsRecovery` is
+/// the explicit landing pad for FIFO data-plane operations after a failed
+/// cursor recovery (PUSH/POP/GET_CHAN_LEN return `CursorRecoveryRequired`
+/// while DELETE/JOIN/LEAVE-non-owner/etc still work).
+pub(crate) enum FifoState {
+  Healthy(super::fifo_cursor::FifoCursor),
+  NeedsRecovery,
+}
+
 /// A channel.
 struct Channel<ML: MessageLog> {
   handler: StringAtom,
@@ -338,6 +359,7 @@ struct Channel<ML: MessageLog> {
   flush_cancel_tx: Option<Sender<()>>,
   /// The storage hash for this channel. `Some` for persistent channels, `None` for transient.
   store_hash: Option<StringAtom>,
+  kind: ChannelKind,
 }
 
 // === impl Channel ===
@@ -356,6 +378,7 @@ impl<ML: MessageLog> Channel<ML> {
       message_log: Rc::new(message_log),
       flush_cancel_tx: None,
       store_hash: None,
+      kind: ChannelKind::PubSub,
     }
   }
 
@@ -501,6 +524,21 @@ impl<ML: MessageLog> Channel<ML> {
       config: self.config.clone(),
       acl: self.acl.clone(),
       members: self.members.clone(),
+      channel_type: self.channel_type(),
+    }
+  }
+
+  fn channel_type(&self) -> ChannelType {
+    match &self.kind {
+      ChannelKind::PubSub => ChannelType::PubSub,
+      ChannelKind::Fifo(_) => ChannelType::Fifo,
+    }
+  }
+
+  fn wire_type_str(&self) -> &'static str {
+    match &self.kind {
+      ChannelKind::PubSub => "pubsub",
+      ChannelKind::Fifo(_) => "fifo",
     }
   }
 }
@@ -563,11 +601,36 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       };
 
       let handler = persisted.handler.clone();
-      let message_log = match self.message_log_factory.create(&handler).await {
+      let mode = match persisted.channel_type {
+        ChannelType::PubSub => LogMode::PubSub,
+        ChannelType::Fifo => LogMode::Fifo,
+      };
+      let message_log = match self.message_log_factory.create(&handler, mode).await {
         Ok(log) => log,
         Err(e) => {
           warn!(handler = %handler, error = %e, "skipping channel restore: failed to create message log");
           continue;
+        },
+      };
+
+      let kind = match persisted.channel_type {
+        ChannelType::PubSub => ChannelKind::PubSub,
+        ChannelType::Fifo => {
+          let log_first = message_log.first_seq();
+          let log_last = message_log.last_seq();
+          match self.message_log_factory.channel_dir(&handler) {
+            Some(channel_dir) => match FifoCursor::load(channel_dir, log_first, log_last).await {
+              Ok(cursor) => ChannelKind::Fifo(FifoState::Healthy(cursor)),
+              Err(e) => {
+                warn!(handler = %handler, error = %e, "FIFO cursor recovery failed; channel restored in NeedsRecovery state");
+                ChannelKind::Fifo(FifoState::NeedsRecovery)
+              },
+            },
+            None => {
+              warn!(handler = %handler, "FIFO channel restore: factory has no on-disk channel_dir; restoring as NeedsRecovery");
+              ChannelKind::Fifo(FifoState::NeedsRecovery)
+            },
+          }
         },
       };
 
@@ -577,6 +640,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       channel.members = persisted.members;
       channel.store_hash = Some(hash.clone());
       channel.seq = channel.message_log.last_seq() + 1;
+      channel.kind = kind;
       channel.update_allowed_targets();
 
       // Use u32::MAX to bypass the per-client limit: persisted membership is authoritative
@@ -626,8 +690,17 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
         let result = self.get_channel_configuration(channel_id, nid, transmitter, correlation_id);
         let _ = reply_tx.send(result).await;
       },
-      Command::SetChannelConfiguration { config, channel_id, nid, transmitter, correlation_id, reply_tx } => {
-        let result = self.set_channel_configuration(config, channel_id, nid, transmitter, correlation_id).await;
+      Command::SetChannelConfiguration {
+        config,
+        requested_type,
+        channel_id,
+        nid,
+        transmitter,
+        correlation_id,
+        reply_tx,
+      } => {
+        let result =
+          self.set_channel_configuration(config, requested_type, channel_id, nid, transmitter, correlation_id).await;
         let _ = reply_tx.send(result).await;
       },
       Command::FilterOwnedChannels { nid, handlers, reply_tx } => {
@@ -705,7 +778,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
         persist: Some(false),
         message_flush_interval: Some(0),
       };
-      let message_log = match self.message_log_factory.create(&handler).await {
+      let message_log = match self.message_log_factory.create(&handler, LogMode::PubSub).await {
         Ok(log) => log,
         Err(e) => {
           warn!(handler = %handler, error = %e, "failed to create message log for new channel");
@@ -890,6 +963,20 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       }
     }
 
+    let owner_leaving_fifo = {
+      let channel = self.channels.get(&channel_id.handler).unwrap();
+      matches!(channel.kind, ChannelKind::Fifo(_)) && channel.is_owner(&left_member_nid)
+    };
+    if owner_leaving_fifo {
+      let Some(tx) = transmitter else {
+        return Err(narwhal_protocol::Error::new(InternalServerError).with_id(correlation_id).into());
+      };
+      self.do_delete_channel(&channel_id, tx.clone()).await?;
+      tx.send_message(Message::LeaveChannelAck(LeaveChannelAckParameters { id: correlation_id }));
+      self.metrics.channel_leaves.inc();
+      return Ok(());
+    }
+
     let excluding_resource = transmitter.as_ref().map(|t| t.resource());
     self.do_leave(&channel_id.handler.clone(), &left_member_nid, excluding_resource).await?;
 
@@ -953,7 +1040,26 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       return Err(narwhal_protocol::Error::new(Forbidden).with_id(correlation_id).into());
     }
 
-    channel.notify_channel_deleted(Some(transmitter.resource()), self.local_domain.clone()).await?;
+    self.do_delete_channel(&channel_id, transmitter.clone()).await?;
+    transmitter.send_message(Message::DeleteChannelAck(DeleteChannelAckParameters { id: correlation_id }));
+    Ok(())
+  }
+
+  /// Runs the full delete-channel machinery: notify members, release
+  /// membership slots, cancel flush task, final flush, drop persistent
+  /// storage (including the FIFO cursor sidecar), and remove the
+  /// in-memory channel. Does **not** send the request ack — callers do
+  /// that based on which command initiated the delete (DELETE_ACK,
+  /// LEAVE_ACK, etc.).
+  async fn do_delete_channel(
+    &mut self,
+    channel_id: &ChannelId,
+    transmitter: Arc<dyn Transmitter>,
+  ) -> anyhow::Result<()> {
+    {
+      let channel = self.channels.get(&channel_id.handler).expect("caller verified channel exists");
+      channel.notify_channel_deleted(Some(transmitter.resource()), self.local_domain.clone()).await?;
+    }
 
     // Collect member usernames to release membership slots.
     let member_usernames: Vec<StringAtom> =
@@ -963,10 +1069,19 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       self.membership.release_slot(username, &channel_id.handler).await;
     }
 
-    // Cancel flush task and perform final flush before cleanup.
+    // Cancel flush task and perform final flush before cleanup. Capture
+    // the FIFO cursor (if any) up front so we can delete its sidecar
+    // outside the &mut channel borrow once `delete_persistent_storage`
+    // takes the channel mutably.
     let is_persistent = self.channels.get(&channel_id.handler).is_some_and(|c| c.config.persist == Some(true));
+    let mut fifo_cursor_to_delete: Option<FifoCursor> = None;
     if let Some(channel) = self.channels.get_mut(&channel_id.handler) {
       channel.cancel_flush_task();
+      if let ChannelKind::Fifo(state) = std::mem::replace(&mut channel.kind, ChannelKind::PubSub) {
+        if let FifoState::Healthy(cursor) = state {
+          fifo_cursor_to_delete = Some(cursor);
+        }
+      }
       if is_persistent {
         let start = Instant::now();
         let result = channel.message_log.flush().await;
@@ -977,14 +1092,22 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       }
     }
 
+    // Best-effort cursor sidecar removal. Errors here would only matter
+    // if the channel directory itself stays around for some reason; the
+    // store cleanup below removes the directory, so a stranded cursor
+    // bin is harmless beyond the immediate failure log.
+    if let Some(cursor) = fifo_cursor_to_delete
+      && let Err(e) = cursor.delete().await
+    {
+      warn!(channel = %channel_id.handler, error = %e, "failed to remove FIFO cursor sidecar");
+    }
+
     // Clean up persistent storage. Best effort, must not block channel removal or leak slots.
     if is_persistent {
       self.delete_persistent_storage(&channel_id.handler).await;
     }
 
     self.channels.remove(&channel_id.handler);
-
-    transmitter.send_message(Message::DeleteChannelAck(DeleteChannelAckParameters { id: correlation_id }));
 
     self.total_channels.fetch_sub(1, Ordering::SeqCst);
     self.metrics.channels_deleted.inc();
@@ -1009,6 +1132,10 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
     let Some(channel) = self.channels.get_mut(&channel_id.handler) else {
       return Err(narwhal_protocol::Error::new(ChannelNotFound).with_id(correlation_id).into());
     };
+
+    if matches!(channel.kind, ChannelKind::Fifo(_)) {
+      return Err(narwhal_protocol::Error::new(WrongType).with_id(correlation_id).into());
+    }
 
     if !channel.is_member(&nid) {
       return Err(narwhal_protocol::Error::new(Forbidden).with_id(correlation_id).into());
@@ -1226,14 +1353,17 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       max_persist_messages: config.max_persist_messages.unwrap_or(0),
       persist: config.persist.unwrap_or(false),
       message_flush_interval: config.message_flush_interval.unwrap_or(0),
+      r#type: StringAtom::from(channel.wire_type_str()),
     }));
 
     Ok(())
   }
 
+  #[allow(clippy::too_many_arguments)]
   async fn set_channel_configuration(
     &mut self,
     config: ChannelConfig,
+    requested_type: Option<ChannelType>,
     channel_id: ChannelId,
     nid: Nid,
     transmitter: Arc<dyn Transmitter>,
@@ -1294,6 +1424,22 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       return Err(narwhal_protocol::Error::new(Forbidden).with_id(correlation_id).into());
     }
 
+    let current_type = channel.channel_type();
+    // FIFO is one-way: pub/sub → fifo is allowed, fifo → pub/sub is not.
+    if let Some(req) = requested_type
+      && current_type == ChannelType::Fifo
+      && req == ChannelType::PubSub
+    {
+      return Err(
+        narwhal_protocol::Error::new(BadRequest)
+          .with_id(correlation_id)
+          .with_detail("FIFO is one-way; cannot revert to pubsub")
+          .into(),
+      );
+    }
+    let new_type = requested_type.unwrap_or(current_type);
+    let transitioning_to_fifo = current_type == ChannelType::PubSub && new_type == ChannelType::Fifo;
+
     let was_persistent = channel.config.persist == Some(true);
     let flush_interval_changed =
       config.message_flush_interval.is_some() && config.message_flush_interval != channel.config.message_flush_interval;
@@ -1309,6 +1455,92 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       );
     }
 
+    // FIFO requires durable storage with a non-zero retention.
+    if new_type == ChannelType::Fifo
+      && (!is_persistent || new_config.max_persist_messages.unwrap_or(0) == 0)
+    {
+      return Err(
+        narwhal_protocol::Error::new(BadRequest)
+          .with_id(correlation_id)
+          .with_detail("FIFO requires persist=true and max_persist_messages > 0")
+          .into(),
+      );
+    }
+
+    let config_unchanged = new_config_equals(&channel.config, &new_config);
+    let no_op = config_unchanged && !transitioning_to_fifo;
+
+    if transitioning_to_fifo {
+      // Step 1: flush so log.last_seq() is durable.
+      let start = Instant::now();
+      let flush_result = channel.message_log.flush().await;
+      self.metrics.record_flush(start, &flush_result);
+      flush_result?;
+
+      // Step 2: derive the new starting seq.
+      let new_next_seq = channel.message_log.last_seq() + 1;
+
+      // Step 3: atomic-write cursor.bin (durable) before publishing the
+      // FIFO type via metadata.bin.
+      let channel_dir = match self.message_log_factory.channel_dir(&channel_id.handler) {
+        Some(dir) => dir,
+        None => {
+          return Err(
+            narwhal_protocol::Error::new(InternalServerError)
+              .with_id(correlation_id)
+              .with_detail("FIFO transition not supported by this storage backend")
+              .into(),
+          );
+        },
+      };
+      let cursor = match FifoCursor::write_initial(channel_dir, new_next_seq).await {
+        Ok(cursor) => cursor,
+        Err(e) => {
+          warn!(channel = %channel_id.handler, error = %e, "FIFO cursor write failed; transition aborted");
+          return Err(narwhal_protocol::Error::new(InternalServerError).with_id(correlation_id).into());
+        },
+      };
+
+      // Step 4: persist metadata with channel_type=Fifo. After this point
+      // the transition is durable on disk.
+      let mut projected = channel.to_persisted();
+      projected.config = new_config.clone();
+      projected.channel_type = ChannelType::Fifo;
+      let store_start = Instant::now();
+      let save_result = self.store.save_channel(&projected).await;
+      self.metrics.store_save_duration_seconds.observe(store_start.elapsed().as_secs_f64());
+      match save_result {
+        Ok(hash) => {
+          self.metrics.store_saves.get_or_create(&SUCCESS).inc();
+          channel.store_hash = Some(hash);
+        },
+        Err(e) => {
+          self.metrics.store_saves.get_or_create(&FAILURE).inc();
+          // Cursor is stranded on disk. `load_channel_hashes` cleans up
+          // directories whose metadata.bin is absent on next restart, and
+          // the next successful retry of this same transition will
+          // overwrite it. No in-memory state changed yet — leave the
+          // channel as pub/sub and surface the error.
+          return Err(e);
+        },
+      }
+
+      // Step 5: in-memory mutations (infallible from here).
+      channel.message_log.switch_to_fifo_mode();
+      channel.seq = new_next_seq;
+      channel.kind = ChannelKind::Fifo(FifoState::Healthy(cursor));
+      channel.config = new_config.clone();
+
+      // Steps 6/7: emit reconfigured event + ack.
+      Self::emit_channel_reconfigured(channel, &channel_id, transmitter.clone(), self.local_domain.clone()).await;
+      transmitter.send_message(Message::SetChannelConfigurationAck(SetChannelConfigurationAckParameters {
+        id: correlation_id,
+      }));
+      return Ok(());
+    }
+
+    // Non-transition path (unchanged from pre-FIFO behavior, plus event
+    // emission on any successful change).
     if is_persistent {
       let mut projected = channel.to_persisted();
       projected.config = new_config.clone();
@@ -1357,10 +1589,31 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       channel.store_hash = None;
     }
 
+    if !no_op {
+      let channel = self.channels.get(&channel_id.handler).unwrap();
+      Self::emit_channel_reconfigured(channel, &channel_id, transmitter.clone(), self.local_domain.clone()).await;
+    }
+
     transmitter
       .send_message(Message::SetChannelConfigurationAck(SetChannelConfigurationAckParameters { id: correlation_id }));
 
     Ok(())
+  }
+
+  /// Notifies all members of a successful CHAN_CONFIG change. The event
+  /// excludes the caller's resource (the issuing client receives the ACK,
+  /// not the event).
+  async fn emit_channel_reconfigured(
+    channel: &Channel<MLF::Log>,
+    channel_id: &ChannelId,
+    transmitter: Arc<dyn Transmitter>,
+    local_domain: StringAtom,
+  ) {
+    let event_channel_id = ChannelId::new_unchecked(channel_id.handler.clone(), local_domain);
+    let event = Event::new(EventKind::ChannelReconfigured).with_channel(event_channel_id.into());
+    if let Err(e) = channel.notifier.notify(event, channel.members.iter(), Some(transmitter.resource())).await {
+      warn!(channel = %channel_id.handler, error = %e, "failed to notify CHANNEL_RECONFIGURED");
+    }
   }
 
   fn filter_owned_channels(&self, nid: &Nid, handlers: &[StringAtom]) -> Vec<StringAtom> {
@@ -1447,6 +1700,10 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       return Err(narwhal_protocol::Error::new(ChannelNotFound).with_id(correlation_id).into());
     };
 
+    if matches!(channel.kind, ChannelKind::Fifo(_)) {
+      return Err(narwhal_protocol::Error::new(WrongType).with_id(correlation_id).into());
+    }
+
     if !channel.is_member(&nid) {
       return Err(narwhal_protocol::Error::new(UserNotInChannel).with_id(correlation_id).into());
     }
@@ -1496,6 +1753,10 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
     let Some(channel) = self.channels.get(&channel_id.handler) else {
       return Err(narwhal_protocol::Error::new(ChannelNotFound).with_id(correlation_id).into());
     };
+
+    if matches!(channel.kind, ChannelKind::Fifo(_)) {
+      return Err(narwhal_protocol::Error::new(WrongType).with_id(correlation_id).into());
+    }
 
     if !channel.is_member(&nid) {
       return Err(narwhal_protocol::Error::new(UserNotInChannel).with_id(correlation_id).into());
@@ -1650,6 +1911,20 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
 
     Ok(true)
   }
+}
+
+/// Field-by-field equality on `ChannelConfig` used to detect a no-op
+/// `SET_CHAN_CONFIG` (so `CHANNEL_RECONFIGURED` does not fire for an
+/// identical re-submission). `ChannelConfig` does not derive `PartialEq`
+/// because it is shared with `PersistedChannel` via serde and adding the
+/// derive there would lock us into pre-prod schema decisions; a small
+/// local helper is cheaper than that.
+fn new_config_equals(a: &ChannelConfig, b: &ChannelConfig) -> bool {
+  a.max_clients == b.max_clients
+    && a.max_payload_size == b.max_payload_size
+    && a.max_persist_messages == b.max_persist_messages
+    && a.persist == b.persist
+    && a.message_flush_interval == b.message_flush_interval
 }
 
 /// Limits for the channel manager.
@@ -2032,9 +2307,11 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelManager<CS, MLF> {
   }
 
   /// Sets the configuration for a channel.
+  #[allow(clippy::too_many_arguments)]
   pub async fn set_channel_configuration(
     &self,
     config: ChannelConfig,
+    requested_type: Option<ChannelType>,
     channel_id: ChannelId,
     nid: Nid,
     transmitter: Arc<dyn Transmitter>,
@@ -2046,7 +2323,15 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelManager<CS, MLF> {
     let (reply_tx, reply_rx) = async_channel::bounded(1);
 
     self.mailboxes[shard]
-      .send(Command::SetChannelConfiguration { config, channel_id, nid, transmitter, correlation_id, reply_tx })
+      .send(Command::SetChannelConfiguration {
+        config,
+        requested_type,
+        channel_id,
+        nid,
+        transmitter,
+        correlation_id,
+        reply_tx,
+      })
       .await?;
 
     reply_rx.recv().await?

--- a/crates/server/src/channel/manager.rs
+++ b/crates/server/src/channel/manager.rs
@@ -1456,9 +1456,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
     }
 
     // FIFO requires durable storage with a non-zero retention.
-    if new_type == ChannelType::Fifo
-      && (!is_persistent || new_config.max_persist_messages.unwrap_or(0) == 0)
-    {
+    if new_type == ChannelType::Fifo && (!is_persistent || new_config.max_persist_messages.unwrap_or(0) == 0) {
       return Err(
         narwhal_protocol::Error::new(BadRequest)
           .with_id(correlation_id)
@@ -1533,9 +1531,8 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
 
       // Steps 6/7: emit reconfigured event + ack.
       Self::emit_channel_reconfigured(channel, &channel_id, transmitter.clone(), self.local_domain.clone()).await;
-      transmitter.send_message(Message::SetChannelConfigurationAck(SetChannelConfigurationAckParameters {
-        id: correlation_id,
-      }));
+      transmitter
+        .send_message(Message::SetChannelConfigurationAck(SetChannelConfigurationAckParameters { id: correlation_id }));
       return Ok(());
     }
 

--- a/crates/server/src/channel/manager.rs
+++ b/crates/server/src/channel/manager.rs
@@ -1077,10 +1077,10 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
     let mut fifo_cursor_to_delete: Option<FifoCursor> = None;
     if let Some(channel) = self.channels.get_mut(&channel_id.handler) {
       channel.cancel_flush_task();
-      if let ChannelKind::Fifo(state) = std::mem::replace(&mut channel.kind, ChannelKind::PubSub) {
-        if let FifoState::Healthy(cursor) = state {
-          fifo_cursor_to_delete = Some(cursor);
-        }
+      if let ChannelKind::Fifo(FifoState::Healthy(cursor)) =
+        std::mem::replace(&mut channel.kind, ChannelKind::PubSub)
+      {
+        fifo_cursor_to_delete = Some(cursor);
       }
       if is_persistent {
         let start = Instant::now();

--- a/crates/server/src/channel/mod.rs
+++ b/crates/server/src/channel/mod.rs
@@ -2,9 +2,9 @@
 
 mod manager;
 
+pub(crate) mod fifo_cursor;
 pub mod file_message_log;
 pub mod file_store;
-pub(crate) mod fifo_cursor;
 pub(crate) mod membership;
 pub mod store;
 

--- a/crates/server/src/channel/mod.rs
+++ b/crates/server/src/channel/mod.rs
@@ -4,8 +4,9 @@ mod manager;
 
 pub mod file_message_log;
 pub mod file_store;
+pub(crate) mod fifo_cursor;
 pub(crate) mod membership;
 pub mod store;
 
 pub use manager::{ChannelAcl, ChannelConfig, ChannelManager, ChannelManagerLimits};
-pub use store::{LogEntry, LogVisitor, NoopMessageLog, NoopMessageLogFactory};
+pub use store::{ChannelType, LogEntry, LogVisitor, NoopMessageLog, NoopMessageLogFactory};

--- a/crates/server/src/channel/store.rs
+++ b/crates/server/src/channel/store.rs
@@ -19,6 +19,19 @@ pub struct PersistedChannel {
   pub acl: ChannelAcl,
   #[serde(with = "rc_slice_serde")]
   pub members: Rc<[Nid]>,
+  pub channel_type: ChannelType,
+}
+
+/// Server-side channel-kind marker, persisted in `metadata.bin` to recover
+/// the correct channel mode on restart.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ChannelType {
+  /// Pub/sub channel: BROADCAST → all members, persistence is opt-in for
+  /// HISTORY replay.
+  #[default]
+  PubSub,
+  /// FIFO work-queue channel: PUSH (owner) → POP (any member, destructive).
+  Fifo,
 }
 
 mod rc_slice_serde {
@@ -61,13 +74,42 @@ pub trait MessageLogFactory: Clone + Send + Sync + 'static {
   /// The message log type produced by this factory.
   type Log: MessageLog;
 
-  /// Creates a message log for the given channel handler.
+  /// Creates a message log for the given channel handler in the requested
+  /// mode.
+  ///
+  /// `mode` selects whether the log is opened in pub/sub mode (count-based
+  /// tail eviction on append) or FIFO mode (head-driven eviction via
+  /// `evict_below`, with the tail-segment-retention invariant). For
+  /// startup-restore the mode is derived from the persisted `channel_type`;
+  /// for the in-runtime pub/sub → FIFO transition the manager calls
+  /// `switch_to_fifo_mode` on the live log instead.
   ///
   /// Implementations may perform fallible I/O (e.g. opening the channel
   /// directory, recovering on-disk state, memory-mapping index files). Errors
   /// are returned so the caller can refuse to bring the affected channel
   /// online; the rest of the server keeps running.
-  async fn create(&self, handler: &StringAtom) -> anyhow::Result<Self::Log>;
+  async fn create(&self, handler: &StringAtom, mode: LogMode) -> anyhow::Result<Self::Log>;
+
+  /// On-disk directory where the FIFO head-cursor sidecar (`cursor.bin`)
+  /// for this channel lives. `None` means the backend is in-memory or
+  /// otherwise has no on-disk channel directory; FIFO transitions and FIFO
+  /// recovery require `Some`.
+  fn channel_dir(&self, _handler: &StringAtom) -> Option<std::path::PathBuf> {
+    None
+  }
+}
+
+/// Mode hint passed to `MessageLogFactory::create`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum LogMode {
+  /// Pub/sub semantics: tail eviction on append once `max_persist_messages`
+  /// is exceeded; no head cursor, no head-driven eviction.
+  #[default]
+  PubSub,
+  /// FIFO semantics: tail eviction is disabled; eviction is driven by
+  /// `evict_below` from the manager (called after the head cursor advances
+  /// on POP).
+  Fifo,
 }
 
 /// A single entry read from the message log.
@@ -120,6 +162,29 @@ pub trait MessageLog: 'static {
   async fn read(&self, from_seq: u64, limit: u32, visitor: &mut impl LogVisitor) -> anyhow::Result<u32>
   where
     Self: Sized;
+
+  /// Highest sequence number that has been fsynced to disk, or 0 if no
+  /// entry has been fsynced yet. Always `<= last_seq()`.
+  ///
+  /// FIFO POP uses this to skip a redundant `flush()` when the entry at the
+  /// cursor is already durable.
+  fn last_durable_seq(&self) -> u64;
+
+  /// One-shot transition from pub/sub mode to FIFO mode. After this call:
+  ///
+  /// - `append` no longer tail-evicts based on `max_messages`.
+  /// - `evict_below(seq)` becomes the only eviction path.
+  /// - The tail-segment-retention invariant is enforced by `evict_below`.
+  ///
+  /// No-op if the log is already in FIFO mode.
+  fn switch_to_fifo_mode(&self);
+
+  /// Drops sealed segments whose `last_seq < seq`, except the segment that
+  /// contains `last_seq()` (tail-segment-retention invariant: the active
+  /// segment is never evicted, so there is always a place to append into).
+  ///
+  /// No-op in pub/sub mode and cheap when no segment qualifies.
+  async fn evict_below(&self, seq: u64) -> anyhow::Result<()>;
 }
 
 /// A no-op message log that discards all writes and returns empty results.
@@ -155,6 +220,16 @@ impl MessageLog for NoopMessageLog {
   {
     Ok(0)
   }
+
+  fn last_durable_seq(&self) -> u64 {
+    0
+  }
+
+  fn switch_to_fifo_mode(&self) {}
+
+  async fn evict_below(&self, _seq: u64) -> anyhow::Result<()> {
+    Ok(())
+  }
 }
 
 /// A no-op message log factory that produces `NoopMessageLog` instances.
@@ -167,7 +242,68 @@ pub struct NoopMessageLogFactory;
 impl MessageLogFactory for NoopMessageLogFactory {
   type Log = NoopMessageLog;
 
-  async fn create(&self, _handler: &StringAtom) -> anyhow::Result<NoopMessageLog> {
+  async fn create(&self, _handler: &StringAtom, _mode: LogMode) -> anyhow::Result<NoopMessageLog> {
     Ok(NoopMessageLog)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::channel::manager::{ChannelAcl, ChannelConfig};
+
+  fn sample_channel(channel_type: ChannelType) -> PersistedChannel {
+    PersistedChannel {
+      handler: StringAtom::from("ch"),
+      owner: None,
+      config: ChannelConfig::default(),
+      acl: ChannelAcl::default(),
+      members: Rc::from([]),
+      channel_type,
+    }
+  }
+
+  #[test]
+  fn channel_type_postcard_round_trip() {
+    for ct in [ChannelType::PubSub, ChannelType::Fifo] {
+      let bytes = postcard::to_allocvec(&ct).unwrap();
+      let decoded: ChannelType = postcard::from_bytes(&bytes).unwrap();
+      assert_eq!(decoded, ct);
+    }
+  }
+
+  #[test]
+  fn persisted_channel_postcard_round_trip() {
+    for ct in [ChannelType::PubSub, ChannelType::Fifo] {
+      let original = sample_channel(ct);
+      let bytes = postcard::to_allocvec(&original).unwrap();
+      let decoded: PersistedChannel = postcard::from_bytes(&bytes).unwrap();
+      assert_eq!(decoded.channel_type, ct);
+      assert_eq!(decoded.handler, original.handler);
+    }
+  }
+
+  // The pre-FIFO PersistedChannel layout (without `channel_type`).
+  #[derive(serde::Serialize)]
+  struct LegacyPersistedChannel {
+    handler: StringAtom,
+    owner: Option<narwhal_protocol::Nid>,
+    config: ChannelConfig,
+    acl: ChannelAcl,
+    members: Vec<narwhal_protocol::Nid>,
+  }
+
+  #[test]
+  fn legacy_metadata_fails_to_decode() {
+    let legacy = LegacyPersistedChannel {
+      handler: StringAtom::from("ch"),
+      owner: None,
+      config: ChannelConfig::default(),
+      acl: ChannelAcl::default(),
+      members: Vec::new(),
+    };
+    let bytes = postcard::to_allocvec(&legacy).unwrap();
+    let result: Result<PersistedChannel, _> = postcard::from_bytes(&bytes);
+    assert!(result.is_err(), "legacy bytes must not deserialize into the new schema");
   }
 }

--- a/crates/server/src/channel/store.rs
+++ b/crates/server/src/channel/store.rs
@@ -49,51 +49,6 @@ mod rc_slice_serde {
   }
 }
 
-/// Pre-FIFO `PersistedChannel` layout, without `channel_type`. Used to
-/// decode `metadata.bin` files written by a build that predates the FIFO
-/// channel slice. Postcard is non-self-describing, so the canonical
-/// schema cannot be made tolerant of the missing trailing field with
-/// `#[serde(default)]` alone; this struct backs an explicit fallback
-/// decode in `decode_persisted_channel`.
-#[derive(serde::Serialize, serde::Deserialize)]
-pub(super) struct LegacyPersistedChannel {
-  pub handler: StringAtom,
-  pub owner: Option<Nid>,
-  pub config: ChannelConfig,
-  pub acl: ChannelAcl,
-  pub members: Vec<Nid>,
-}
-
-impl LegacyPersistedChannel {
-  fn into_persisted(self) -> PersistedChannel {
-    PersistedChannel {
-      handler: self.handler,
-      owner: self.owner,
-      config: self.config,
-      acl: self.acl,
-      members: Rc::from(self.members),
-      channel_type: ChannelType::PubSub,
-    }
-  }
-}
-
-/// Decodes a `PersistedChannel` from on-disk bytes. If the canonical
-/// (FIFO-aware) schema fails to decode, falls back to the pre-FIFO
-/// layout and defaults `channel_type` to [`ChannelType::PubSub`] so a
-/// server upgraded from a build without the field keeps its persisted
-/// channels on restart. If both decodes fail, the canonical schema's
-/// error is returned so the diagnostic reflects the format the server
-/// actually expects.
-pub(super) fn decode_persisted_channel(bytes: &[u8]) -> Result<PersistedChannel, postcard::Error> {
-  match postcard::from_bytes::<PersistedChannel>(bytes) {
-    Ok(channel) => Ok(channel),
-    Err(canonical_err) => match postcard::from_bytes::<LegacyPersistedChannel>(bytes) {
-      Ok(legacy) => Ok(legacy.into_persisted()),
-      Err(_) => Err(canonical_err),
-    },
-  }
-}
-
 /// Storage backend for persisting channel metadata.
 #[async_trait(?Send)]
 pub trait ChannelStore: Clone + Send + Sync + 'static {
@@ -328,8 +283,18 @@ mod tests {
     }
   }
 
+  // The pre-FIFO PersistedChannel layout (without `channel_type`).
+  #[derive(serde::Serialize)]
+  struct LegacyPersistedChannel {
+    handler: StringAtom,
+    owner: Option<narwhal_protocol::Nid>,
+    config: ChannelConfig,
+    acl: ChannelAcl,
+    members: Vec<narwhal_protocol::Nid>,
+  }
+
   #[test]
-  fn legacy_metadata_decodes_as_pubsub() {
+  fn legacy_metadata_fails_to_decode() {
     let legacy = LegacyPersistedChannel {
       handler: StringAtom::from("ch"),
       owner: None,
@@ -338,19 +303,7 @@ mod tests {
       members: Vec::new(),
     };
     let bytes = postcard::to_allocvec(&legacy).unwrap();
-    let decoded = decode_persisted_channel(&bytes).expect("legacy bytes must decode via fallback");
-    assert_eq!(decoded.channel_type, ChannelType::PubSub);
-    assert_eq!(decoded.handler.as_ref(), "ch");
-  }
-
-  #[test]
-  fn current_metadata_decodes_via_helper() {
-    for ct in [ChannelType::PubSub, ChannelType::Fifo] {
-      let original = sample_channel(ct);
-      let bytes = postcard::to_allocvec(&original).unwrap();
-      let decoded = decode_persisted_channel(&bytes).expect("current bytes must decode");
-      assert_eq!(decoded.channel_type, ct);
-      assert_eq!(decoded.handler, original.handler);
-    }
+    let result: Result<PersistedChannel, _> = postcard::from_bytes(&bytes);
+    assert!(result.is_err(), "legacy bytes must not deserialize into the new schema");
   }
 }

--- a/crates/server/src/channel/store.rs
+++ b/crates/server/src/channel/store.rs
@@ -49,6 +49,51 @@ mod rc_slice_serde {
   }
 }
 
+/// Pre-FIFO `PersistedChannel` layout, without `channel_type`. Used to
+/// decode `metadata.bin` files written by a build that predates the FIFO
+/// channel slice. Postcard is non-self-describing, so the canonical
+/// schema cannot be made tolerant of the missing trailing field with
+/// `#[serde(default)]` alone; this struct backs an explicit fallback
+/// decode in `decode_persisted_channel`.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(super) struct LegacyPersistedChannel {
+  pub handler: StringAtom,
+  pub owner: Option<Nid>,
+  pub config: ChannelConfig,
+  pub acl: ChannelAcl,
+  pub members: Vec<Nid>,
+}
+
+impl LegacyPersistedChannel {
+  fn into_persisted(self) -> PersistedChannel {
+    PersistedChannel {
+      handler: self.handler,
+      owner: self.owner,
+      config: self.config,
+      acl: self.acl,
+      members: Rc::from(self.members),
+      channel_type: ChannelType::PubSub,
+    }
+  }
+}
+
+/// Decodes a `PersistedChannel` from on-disk bytes. If the canonical
+/// (FIFO-aware) schema fails to decode, falls back to the pre-FIFO
+/// layout and defaults `channel_type` to [`ChannelType::PubSub`] so a
+/// server upgraded from a build without the field keeps its persisted
+/// channels on restart. If both decodes fail, the canonical schema's
+/// error is returned so the diagnostic reflects the format the server
+/// actually expects.
+pub(super) fn decode_persisted_channel(bytes: &[u8]) -> Result<PersistedChannel, postcard::Error> {
+  match postcard::from_bytes::<PersistedChannel>(bytes) {
+    Ok(channel) => Ok(channel),
+    Err(canonical_err) => match postcard::from_bytes::<LegacyPersistedChannel>(bytes) {
+      Ok(legacy) => Ok(legacy.into_persisted()),
+      Err(_) => Err(canonical_err),
+    },
+  }
+}
+
 /// Storage backend for persisting channel metadata.
 #[async_trait(?Send)]
 pub trait ChannelStore: Clone + Send + Sync + 'static {
@@ -283,18 +328,8 @@ mod tests {
     }
   }
 
-  // The pre-FIFO PersistedChannel layout (without `channel_type`).
-  #[derive(serde::Serialize)]
-  struct LegacyPersistedChannel {
-    handler: StringAtom,
-    owner: Option<narwhal_protocol::Nid>,
-    config: ChannelConfig,
-    acl: ChannelAcl,
-    members: Vec<narwhal_protocol::Nid>,
-  }
-
   #[test]
-  fn legacy_metadata_fails_to_decode() {
+  fn legacy_metadata_decodes_as_pubsub() {
     let legacy = LegacyPersistedChannel {
       handler: StringAtom::from("ch"),
       owner: None,
@@ -303,7 +338,19 @@ mod tests {
       members: Vec::new(),
     };
     let bytes = postcard::to_allocvec(&legacy).unwrap();
-    let result: Result<PersistedChannel, _> = postcard::from_bytes(&bytes);
-    assert!(result.is_err(), "legacy bytes must not deserialize into the new schema");
+    let decoded = decode_persisted_channel(&bytes).expect("legacy bytes must decode via fallback");
+    assert_eq!(decoded.channel_type, ChannelType::PubSub);
+    assert_eq!(decoded.handler.as_ref(), "ch");
+  }
+
+  #[test]
+  fn current_metadata_decodes_via_helper() {
+    for ct in [ChannelType::PubSub, ChannelType::Fifo] {
+      let original = sample_channel(ct);
+      let bytes = postcard::to_allocvec(&original).unwrap();
+      let decoded = decode_persisted_channel(&bytes).expect("current bytes must decode");
+      assert_eq!(decoded.channel_type, ct);
+      assert_eq!(decoded.handler, original.handler);
+    }
   }
 }

--- a/crates/server/tests/c2s_channel_persistence_failure.rs
+++ b/crates/server/tests/c2s_channel_persistence_failure.rs
@@ -301,6 +301,7 @@ async fn test_c2s_set_config_fails_when_store_save_fails() -> anyhow::Result<()>
         persist: None,
         max_persist_messages: None,
         message_flush_interval: None,
+        r#type: None,
       }),
     )
     .await?;
@@ -336,6 +337,7 @@ async fn test_c2s_set_config_fails_when_store_save_fails() -> anyhow::Result<()>
       max_persist_messages: default_c2s_config().limits.max_persist_messages,
       persist: true,
       message_flush_interval: 0,
+      r#type: StringAtom::from("pubsub"),
     }
   );
 

--- a/crates/server/tests/c2s_fifo_channel.rs
+++ b/crates/server/tests/c2s_fifo_channel.rs
@@ -194,8 +194,11 @@ async fn test_fifo_transition_persists_across_restart() -> anyhow::Result<()> {
   {
     let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
     let store = FileChannelStore::new(data_dir.clone()).await?;
-    let mlf =
-      FileMessageLogFactory::new(data_dir.clone(), default_c2s_config().limits.max_payload_size, MessageLogMetrics::noop());
+    let mlf = FileMessageLogFactory::new(
+      data_dir.clone(),
+      default_c2s_config().limits.max_payload_size,
+      MessageLogMetrics::noop(),
+    );
 
     let mut suite =
       C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
@@ -215,8 +218,11 @@ async fn test_fifo_transition_persists_across_restart() -> anyhow::Result<()> {
   {
     let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
     let store = FileChannelStore::new(data_dir.clone()).await?;
-    let mlf =
-      FileMessageLogFactory::new(data_dir.clone(), default_c2s_config().limits.max_payload_size, MessageLogMetrics::noop());
+    let mlf = FileMessageLogFactory::new(
+      data_dir.clone(),
+      default_c2s_config().limits.max_payload_size,
+      MessageLogMetrics::noop(),
+    );
 
     let mut suite =
       C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
@@ -274,12 +280,7 @@ async fn test_broadcast_on_fifo_returns_wrong_type() -> anyhow::Result<()> {
   suite
     .write_message(
       TEST_USER_1,
-      Message::Broadcast(BroadcastParameters {
-        id: 7,
-        channel: StringAtom::from(CHANNEL),
-        qos: None,
-        length: 1,
-      }),
+      Message::Broadcast(BroadcastParameters { id: 7, channel: StringAtom::from(CHANNEL), qos: None, length: 1 }),
     )
     .await?;
   // The codec frames the payload as `bytes + \n` after the BROADCAST header.
@@ -369,10 +370,7 @@ async fn test_chan_seq_on_fifo_returns_wrong_type() -> anyhow::Result<()> {
   assert!(matches!(reply, Message::SetChannelConfigurationAck { .. }), "unexpected reply: {:?}", reply);
 
   suite
-    .write_message(
-      TEST_USER_1,
-      Message::ChannelSeq(ChannelSeqParameters { id: 9, channel: StringAtom::from(CHANNEL) }),
-    )
+    .write_message(TEST_USER_1, Message::ChannelSeq(ChannelSeqParameters { id: 9, channel: StringAtom::from(CHANNEL) }))
     .await?;
   match suite.read_message(TEST_USER_1).await? {
     Message::Error(p) => {
@@ -422,11 +420,7 @@ async fn test_owner_leave_on_fifo_auto_deletes() -> anyhow::Result<()> {
   suite
     .write_message(
       TEST_USER_1,
-      Message::LeaveChannel(LeaveChannelParameters {
-        id: 22,
-        channel: StringAtom::from(CHANNEL),
-        on_behalf: None,
-      }),
+      Message::LeaveChannel(LeaveChannelParameters { id: 22, channel: StringAtom::from(CHANNEL), on_behalf: None }),
     )
     .await?;
 

--- a/crates/server/tests/c2s_fifo_channel.rs
+++ b/crates/server/tests/c2s_fifo_channel.rs
@@ -1,0 +1,618 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! Integration tests for the FIFO Channels transition slice (PR 1).
+//!
+//! Tests the in-runtime pub/sub → FIFO transition, restart-preserves-type,
+//! type-aware WRONG_TYPE branches, owner-LEAVE-deletes, and the
+//! CHANNEL_RECONFIGURED event. The data plane (PUSH/POP/GET_CHAN_LEN)
+//! ships in PR 2.
+
+use narwhal_client::S2mConfig;
+use narwhal_client::compio::s2m::S2mClient;
+use narwhal_common::core_dispatcher::CoreDispatcher;
+use narwhal_modulator::create_s2m_listener;
+use narwhal_modulator::modulator::AuthResult;
+use narwhal_protocol::{
+  BroadcastParameters, ChannelSeqParameters, ErrorReason, EventKind, GetChannelConfigurationParameters,
+  HistoryParameters, LeaveChannelParameters, ListChannelsParameters, Message, SetChannelConfigurationParameters,
+};
+use narwhal_server::channel::file_message_log::{FileMessageLogFactory, MessageLogMetrics};
+use narwhal_server::channel::file_store::FileChannelStore;
+use narwhal_test_util::{C2sSuite, TestModulator, default_c2s_config, default_s2m_config};
+use narwhal_util::string_atom::StringAtom;
+use prometheus_client::registry::Registry;
+
+const TEST_USER_1: &str = "test_user_1";
+const TEST_USER_2: &str = "test_user_2";
+const SHARED_SECRET: &str = "test_secret";
+const CHANNEL: &str = "!fifotest@localhost";
+
+fn make_auth_modulator() -> TestModulator {
+  TestModulator::new()
+    .with_auth_handler(|token| async move { Ok(AuthResult::Success { username: StringAtom::from(token.as_ref()) }) })
+}
+
+async fn bootstrap_s2m(
+  modulator: TestModulator,
+) -> anyhow::Result<(S2mClient, narwhal_modulator::S2mListener<TestModulator>, CoreDispatcher)> {
+  let mut core_dispatcher = CoreDispatcher::new(1);
+  core_dispatcher.bootstrap().await?;
+
+  let mut s2m_ln = create_s2m_listener(
+    default_s2m_config(SHARED_SECRET),
+    modulator,
+    core_dispatcher.clone(),
+    &mut Registry::default(),
+  )
+  .await?;
+  s2m_ln.bootstrap().await?;
+
+  let s2m_client = S2mClient::new(S2mConfig {
+    address: s2m_ln.local_address().unwrap().to_string(),
+    shared_secret: SHARED_SECRET.to_string(),
+    ..Default::default()
+  })?;
+
+  Ok((s2m_client, s2m_ln, core_dispatcher))
+}
+
+fn set_config(
+  id: u32,
+  channel: &str,
+  persist: Option<bool>,
+  max_persist_messages: Option<u32>,
+  r#type: Option<&str>,
+) -> Message {
+  Message::SetChannelConfiguration(SetChannelConfigurationParameters {
+    id,
+    channel: StringAtom::from(channel),
+    persist,
+    max_persist_messages,
+    r#type: r#type.map(StringAtom::from),
+    ..Default::default()
+  })
+}
+
+/// Transition validation: persist=false must reject the FIFO request.
+#[compio::test]
+async fn test_fifo_transition_rejects_non_persistent() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = FileMessageLogFactory::new(
+    tmp.path().to_path_buf(),
+    default_c2s_config().limits.max_payload_size,
+    MessageLogMetrics::noop(),
+  );
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  suite.auth(TEST_USER_1, TEST_USER_1).await?;
+  suite.join_channel(TEST_USER_1, CHANNEL, None).await?;
+
+  // Try to declare FIFO without persist=true.
+  suite.write_message(TEST_USER_1, set_config(99, CHANNEL, None, Some(10), Some("fifo"))).await?;
+  match suite.read_message(TEST_USER_1).await? {
+    Message::Error(p) => {
+      assert_eq!(p.id, Some(99));
+      assert_eq!(p.reason, StringAtom::from(ErrorReason::BadRequest));
+      assert_eq!(p.detail.as_deref(), Some("FIFO requires persist=true and max_persist_messages > 0"));
+    },
+    other => panic!("expected Error, got {:?}", other),
+  }
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
+  Ok(())
+}
+
+/// Transition validation: max_persist_messages=0 must reject. The generic
+/// `max_persist_messages > 0` rule fires before the FIFO-specific check
+/// when persist=true is also requested.
+#[compio::test]
+async fn test_fifo_transition_rejects_zero_max_persist_messages() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = FileMessageLogFactory::new(
+    tmp.path().to_path_buf(),
+    default_c2s_config().limits.max_payload_size,
+    MessageLogMetrics::noop(),
+  );
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  suite.auth(TEST_USER_1, TEST_USER_1).await?;
+  suite.join_channel(TEST_USER_1, CHANNEL, None).await?;
+
+  suite.write_message(TEST_USER_1, set_config(11, CHANNEL, Some(true), Some(0), Some("fifo"))).await?;
+  match suite.read_message(TEST_USER_1).await? {
+    Message::Error(p) => {
+      assert_eq!(p.id, Some(11));
+      assert_eq!(p.reason, StringAtom::from(ErrorReason::BadRequest));
+    },
+    other => panic!("expected Error, got {:?}", other),
+  }
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
+  Ok(())
+}
+
+/// FIFO is one-way: rejecting type=pubsub on a channel that is already FIFO.
+#[compio::test]
+async fn test_fifo_to_pubsub_transition_rejected() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = FileMessageLogFactory::new(
+    tmp.path().to_path_buf(),
+    default_c2s_config().limits.max_payload_size,
+    MessageLogMetrics::noop(),
+  );
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  suite.auth(TEST_USER_1, TEST_USER_1).await?;
+  suite.join_channel(TEST_USER_1, CHANNEL, None).await?;
+
+  // Become FIFO.
+  suite.write_message(TEST_USER_1, set_config(1, CHANNEL, Some(true), Some(10), Some("fifo"))).await?;
+  let reply = suite.read_message(TEST_USER_1).await?;
+  assert!(matches!(reply, Message::SetChannelConfigurationAck { .. }), "unexpected reply: {:?}", reply);
+
+  // Try to revert.
+  suite.write_message(TEST_USER_1, set_config(2, CHANNEL, None, None, Some("pubsub"))).await?;
+  match suite.read_message(TEST_USER_1).await? {
+    Message::Error(p) => {
+      assert_eq!(p.id, Some(2));
+      assert_eq!(p.reason, StringAtom::from(ErrorReason::BadRequest));
+      assert_eq!(p.detail.as_deref(), Some("FIFO is one-way; cannot revert to pubsub"));
+    },
+    other => panic!("expected Error, got {:?}", other),
+  }
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
+  Ok(())
+}
+
+/// Restart preserves channel_type=Fifo: after a transition, restart the
+/// server and verify GET_CHAN_CONFIG returns type=fifo.
+#[compio::test]
+async fn test_fifo_transition_persists_across_restart() -> anyhow::Result<()> {
+  let tmp = tempfile::tempdir()?;
+  let data_dir = tmp.path().to_path_buf();
+
+  // First boot: transition to FIFO.
+  {
+    let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+    let store = FileChannelStore::new(data_dir.clone()).await?;
+    let mlf =
+      FileMessageLogFactory::new(data_dir.clone(), default_c2s_config().limits.max_payload_size, MessageLogMetrics::noop());
+
+    let mut suite =
+      C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+    suite.setup().await?;
+
+    suite.auth(TEST_USER_1, TEST_USER_1).await?;
+    suite.join_channel(TEST_USER_1, CHANNEL, None).await?;
+    suite.write_message(TEST_USER_1, set_config(1, CHANNEL, Some(true), Some(10), Some("fifo"))).await?;
+    assert!(matches!(suite.read_message(TEST_USER_1).await?, Message::SetChannelConfigurationAck { .. }));
+
+    suite.teardown().await?;
+    s2m_ln.shutdown().await?;
+    s2m_dispatcher.shutdown().await?;
+  }
+
+  // Second boot: type=fifo on GET_CHAN_CONFIG.
+  {
+    let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+    let store = FileChannelStore::new(data_dir.clone()).await?;
+    let mlf =
+      FileMessageLogFactory::new(data_dir.clone(), default_c2s_config().limits.max_payload_size, MessageLogMetrics::noop());
+
+    let mut suite =
+      C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+    suite.setup().await?;
+
+    suite.auth(TEST_USER_1, TEST_USER_1).await?;
+    suite
+      .write_message(
+        TEST_USER_1,
+        Message::GetChannelConfiguration(GetChannelConfigurationParameters {
+          id: 5,
+          channel: StringAtom::from(CHANNEL),
+        }),
+      )
+      .await?;
+
+    let reply = suite.read_message(TEST_USER_1).await?;
+    if let Message::ChannelConfiguration(p) = reply {
+      assert_eq!(p.r#type.as_ref(), "fifo");
+      assert!(p.persist);
+    } else {
+      panic!("expected ChannelConfiguration, got {:?}", reply);
+    }
+
+    suite.teardown().await?;
+    s2m_ln.shutdown().await?;
+    s2m_dispatcher.shutdown().await?;
+  }
+
+  Ok(())
+}
+
+/// BROADCAST on a FIFO channel returns WRONG_TYPE.
+#[compio::test]
+async fn test_broadcast_on_fifo_returns_wrong_type() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = FileMessageLogFactory::new(
+    tmp.path().to_path_buf(),
+    default_c2s_config().limits.max_payload_size,
+    MessageLogMetrics::noop(),
+  );
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  suite.auth(TEST_USER_1, TEST_USER_1).await?;
+  suite.join_channel(TEST_USER_1, CHANNEL, None).await?;
+  suite.write_message(TEST_USER_1, set_config(1, CHANNEL, Some(true), Some(10), Some("fifo"))).await?;
+  let reply = suite.read_message(TEST_USER_1).await?;
+  assert!(matches!(reply, Message::SetChannelConfigurationAck { .. }), "unexpected reply: {:?}", reply);
+
+  // Try BROADCAST.
+  suite
+    .write_message(
+      TEST_USER_1,
+      Message::Broadcast(BroadcastParameters {
+        id: 7,
+        channel: StringAtom::from(CHANNEL),
+        qos: None,
+        length: 1,
+      }),
+    )
+    .await?;
+  // The codec frames the payload as `bytes + \n` after the BROADCAST header.
+  suite.write_raw_bytes(TEST_USER_1, b"x").await?;
+  suite.write_raw_bytes(TEST_USER_1, b"\n").await?;
+
+  match suite.read_message(TEST_USER_1).await? {
+    Message::Error(p) => {
+      assert_eq!(p.id, Some(7));
+      assert_eq!(p.reason, StringAtom::from(ErrorReason::WrongType));
+    },
+    other => panic!("expected Error, got {:?}", other),
+  }
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
+  Ok(())
+}
+
+/// HISTORY on a FIFO channel returns WRONG_TYPE.
+#[compio::test]
+async fn test_history_on_fifo_returns_wrong_type() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = FileMessageLogFactory::new(
+    tmp.path().to_path_buf(),
+    default_c2s_config().limits.max_payload_size,
+    MessageLogMetrics::noop(),
+  );
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  suite.auth(TEST_USER_1, TEST_USER_1).await?;
+  suite.join_channel(TEST_USER_1, CHANNEL, None).await?;
+  suite.write_message(TEST_USER_1, set_config(1, CHANNEL, Some(true), Some(10), Some("fifo"))).await?;
+  let reply = suite.read_message(TEST_USER_1).await?;
+  assert!(matches!(reply, Message::SetChannelConfigurationAck { .. }), "unexpected reply: {:?}", reply);
+
+  suite
+    .write_message(
+      TEST_USER_1,
+      Message::History(HistoryParameters {
+        id: 8,
+        history_id: StringAtom::from("h1"),
+        channel: StringAtom::from(CHANNEL),
+        from_seq: 1,
+        limit: 10,
+      }),
+    )
+    .await?;
+  match suite.read_message(TEST_USER_1).await? {
+    Message::Error(p) => {
+      assert_eq!(p.id, Some(8));
+      assert_eq!(p.reason, StringAtom::from(ErrorReason::WrongType));
+    },
+    other => panic!("expected Error, got {:?}", other),
+  }
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
+  Ok(())
+}
+
+/// CHAN_SEQ on a FIFO channel returns WRONG_TYPE.
+#[compio::test]
+async fn test_chan_seq_on_fifo_returns_wrong_type() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = FileMessageLogFactory::new(
+    tmp.path().to_path_buf(),
+    default_c2s_config().limits.max_payload_size,
+    MessageLogMetrics::noop(),
+  );
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  suite.auth(TEST_USER_1, TEST_USER_1).await?;
+  suite.join_channel(TEST_USER_1, CHANNEL, None).await?;
+  suite.write_message(TEST_USER_1, set_config(1, CHANNEL, Some(true), Some(10), Some("fifo"))).await?;
+  let reply = suite.read_message(TEST_USER_1).await?;
+  assert!(matches!(reply, Message::SetChannelConfigurationAck { .. }), "unexpected reply: {:?}", reply);
+
+  suite
+    .write_message(
+      TEST_USER_1,
+      Message::ChannelSeq(ChannelSeqParameters { id: 9, channel: StringAtom::from(CHANNEL) }),
+    )
+    .await?;
+  match suite.read_message(TEST_USER_1).await? {
+    Message::Error(p) => {
+      assert_eq!(p.id, Some(9));
+      assert_eq!(p.reason, StringAtom::from(ErrorReason::WrongType));
+    },
+    other => panic!("expected Error, got {:?}", other),
+  }
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
+  Ok(())
+}
+
+/// Owner LEAVE on a FIFO channel auto-deletes: other members receive
+/// CHANNEL_DELETED, the leaver receives LEAVE_ACK, and the channel
+/// disappears from `CHANNELS`.
+#[compio::test]
+async fn test_owner_leave_on_fifo_auto_deletes() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = FileMessageLogFactory::new(
+    tmp.path().to_path_buf(),
+    default_c2s_config().limits.max_payload_size,
+    MessageLogMetrics::noop(),
+  );
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  suite.auth(TEST_USER_1, TEST_USER_1).await?;
+  suite.auth(TEST_USER_2, TEST_USER_2).await?;
+  suite.join_channel(TEST_USER_1, CHANNEL, None).await?;
+  suite.join_channel(TEST_USER_2, CHANNEL, None).await?;
+  // user_1 sees user_2 join.
+  suite.ignore_reply(TEST_USER_1).await?;
+
+  suite.write_message(TEST_USER_1, set_config(1, CHANNEL, Some(true), Some(10), Some("fifo"))).await?;
+  let reply = suite.read_message(TEST_USER_1).await?;
+  assert!(matches!(reply, Message::SetChannelConfigurationAck { .. }), "unexpected reply: {:?}", reply);
+  // user_2 receives CHANNEL_RECONFIGURED.
+  suite.ignore_reply(TEST_USER_2).await?;
+
+  // Owner LEAVEs.
+  suite
+    .write_message(
+      TEST_USER_1,
+      Message::LeaveChannel(LeaveChannelParameters {
+        id: 22,
+        channel: StringAtom::from(CHANNEL),
+        on_behalf: None,
+      }),
+    )
+    .await?;
+
+  // user_1 receives LEAVE_ACK (matches request shape, not DELETE_ACK).
+  let reply = suite.read_message(TEST_USER_1).await?;
+  match reply {
+    Message::LeaveChannelAck(p) => assert_eq!(p.id, 22),
+    other => panic!("expected LeaveChannelAck, got {:?}", other),
+  }
+
+  // user_2 receives CHANNEL_DELETED.
+  match suite.read_message(TEST_USER_2).await? {
+    Message::Event(p) => {
+      assert_eq!(p.kind, StringAtom::from(EventKind::ChannelDeleted));
+      assert_eq!(p.channel.as_deref(), Some(CHANNEL));
+    },
+    other => panic!("expected Event, got {:?}", other),
+  }
+
+  // Channel is gone from user_1's listing.
+  suite
+    .write_message(
+      TEST_USER_1,
+      Message::ListChannels(ListChannelsParameters { id: 30, page: None, page_size: None, owner: false }),
+    )
+    .await?;
+  let listing = suite.read_message(TEST_USER_1).await?;
+  match listing {
+    Message::ListChannelsAck(p) => {
+      assert!(!p.channels.iter().any(|c| c.as_ref() == CHANNEL), "channel should be gone, got: {:?}", p.channels);
+    },
+    other => panic!("expected ListChannelsAck, got {:?}", other),
+  }
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
+  Ok(())
+}
+
+/// CHANNEL_RECONFIGURED fires on the type transition.
+#[compio::test]
+async fn test_channel_reconfigured_fires_on_type_change() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = FileMessageLogFactory::new(
+    tmp.path().to_path_buf(),
+    default_c2s_config().limits.max_payload_size,
+    MessageLogMetrics::noop(),
+  );
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  suite.auth(TEST_USER_1, TEST_USER_1).await?;
+  suite.auth(TEST_USER_2, TEST_USER_2).await?;
+  suite.join_channel(TEST_USER_1, CHANNEL, None).await?;
+  suite.join_channel(TEST_USER_2, CHANNEL, None).await?;
+  // user_1 sees user_2 join.
+  suite.ignore_reply(TEST_USER_1).await?;
+
+  suite.write_message(TEST_USER_1, set_config(40, CHANNEL, Some(true), Some(10), Some("fifo"))).await?;
+  // user_1 receives ACK.
+  assert!(matches!(suite.read_message(TEST_USER_1).await?, Message::SetChannelConfigurationAck { .. }));
+
+  // user_2 receives CHANNEL_RECONFIGURED (and not the ACK or anything else).
+  match suite.read_message(TEST_USER_2).await? {
+    Message::Event(p) => {
+      assert_eq!(p.kind, StringAtom::from(EventKind::ChannelReconfigured));
+      assert_eq!(p.channel.as_deref(), Some(CHANNEL));
+    },
+    other => panic!("expected Event, got {:?}", other),
+  }
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
+  Ok(())
+}
+
+/// CHANNEL_RECONFIGURED fires on a config-only change (e.g. max_clients).
+#[compio::test]
+async fn test_channel_reconfigured_fires_on_config_only_change() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = FileMessageLogFactory::new(
+    tmp.path().to_path_buf(),
+    default_c2s_config().limits.max_payload_size,
+    MessageLogMetrics::noop(),
+  );
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  suite.auth(TEST_USER_1, TEST_USER_1).await?;
+  suite.auth(TEST_USER_2, TEST_USER_2).await?;
+  suite.join_channel(TEST_USER_1, CHANNEL, None).await?;
+  suite.join_channel(TEST_USER_2, CHANNEL, None).await?;
+  suite.ignore_reply(TEST_USER_1).await?;
+
+  // Change max_clients only.
+  suite
+    .write_message(
+      TEST_USER_1,
+      Message::SetChannelConfiguration(SetChannelConfigurationParameters {
+        id: 50,
+        channel: StringAtom::from(CHANNEL),
+        max_clients: Some(33),
+        ..Default::default()
+      }),
+    )
+    .await?;
+  assert!(matches!(suite.read_message(TEST_USER_1).await?, Message::SetChannelConfigurationAck { .. }));
+
+  match suite.read_message(TEST_USER_2).await? {
+    Message::Event(p) => {
+      assert_eq!(p.kind, StringAtom::from(EventKind::ChannelReconfigured));
+      assert_eq!(p.channel.as_deref(), Some(CHANNEL));
+    },
+    other => panic!("expected Event, got {:?}", other),
+  }
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
+  Ok(())
+}
+
+/// CHANNEL_RECONFIGURED is suppressed on a true no-op (identical config
+/// re-submission with no type change).
+#[compio::test]
+async fn test_channel_reconfigured_suppressed_on_no_op() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = FileMessageLogFactory::new(
+    tmp.path().to_path_buf(),
+    default_c2s_config().limits.max_payload_size,
+    MessageLogMetrics::noop(),
+  );
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  suite.auth(TEST_USER_1, TEST_USER_1).await?;
+  suite.auth(TEST_USER_2, TEST_USER_2).await?;
+  suite.join_channel(TEST_USER_1, CHANNEL, None).await?;
+  suite.join_channel(TEST_USER_2, CHANNEL, None).await?;
+  suite.ignore_reply(TEST_USER_1).await?;
+
+  // First change: bumps max_clients to 33; user_2 gets CHANNEL_RECONFIGURED.
+  suite
+    .write_message(
+      TEST_USER_1,
+      Message::SetChannelConfiguration(SetChannelConfigurationParameters {
+        id: 60,
+        channel: StringAtom::from(CHANNEL),
+        max_clients: Some(33),
+        ..Default::default()
+      }),
+    )
+    .await?;
+  assert!(matches!(suite.read_message(TEST_USER_1).await?, Message::SetChannelConfigurationAck { .. }));
+  suite.ignore_reply(TEST_USER_2).await?;
+
+  // Second submission: same max_clients, so it's a no-op.
+  suite
+    .write_message(
+      TEST_USER_1,
+      Message::SetChannelConfiguration(SetChannelConfigurationParameters {
+        id: 61,
+        channel: StringAtom::from(CHANNEL),
+        max_clients: Some(33),
+        ..Default::default()
+      }),
+    )
+    .await?;
+  assert!(matches!(suite.read_message(TEST_USER_1).await?, Message::SetChannelConfigurationAck { .. }));
+
+  // user_2 must NOT receive a second CHANNEL_RECONFIGURED.
+  suite.expect_read_timeout(TEST_USER_2, std::time::Duration::from_millis(500)).await?;
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
+  Ok(())
+}

--- a/crates/server/tests/c2s_modulator_tests.rs
+++ b/crates/server/tests/c2s_modulator_tests.rs
@@ -1039,6 +1039,9 @@ async fn test_c2s_modulator_keep_persistent_channels_on_disconnect() -> anyhow::
     .await?;
   assert!(matches!(suite.read_message(TEST_USER_1).await?, Message::SetChannelConfigurationAck { .. }));
 
+  // User 2 receives a CHANNEL_RECONFIGURED event for the persist toggle.
+  suite.ignore_reply(TEST_USER_2).await?;
+
   // Drop User 1's connection (the only one for that user).
   suite.drop_client(TEST_USER_1)?;
 

--- a/crates/test-util/src/c2s_suite.rs
+++ b/crates/test-util/src/c2s_suite.rs
@@ -358,6 +358,7 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> C2sSuite<CS, MLF> {
           persist,
           max_persist_messages,
           message_flush_interval,
+          r#type: None,
         }),
       )
       .await?;

--- a/crates/test-util/src/mock.rs
+++ b/crates/test-util/src/mock.rs
@@ -7,7 +7,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
 use narwhal_protocol::{Message, Nid};
-use narwhal_server::channel::store::{ChannelStore, ChannelType, LogVisitor, MessageLog, MessageLogFactory, PersistedChannel};
+use narwhal_server::channel::store::{
+  ChannelStore, ChannelType, LogVisitor, MessageLog, MessageLogFactory, PersistedChannel,
+};
 use narwhal_server::channel::{ChannelAcl, ChannelConfig};
 use narwhal_util::pool::PoolBuffer;
 use narwhal_util::string_atom::StringAtom;

--- a/crates/test-util/src/mock.rs
+++ b/crates/test-util/src/mock.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
 use narwhal_protocol::{Message, Nid};
-use narwhal_server::channel::store::{ChannelStore, LogVisitor, MessageLog, MessageLogFactory, PersistedChannel};
+use narwhal_server::channel::store::{ChannelStore, ChannelType, LogVisitor, MessageLog, MessageLogFactory, PersistedChannel};
 use narwhal_server::channel::{ChannelAcl, ChannelConfig};
 use narwhal_util::pool::PoolBuffer;
 use narwhal_util::string_atom::StringAtom;
@@ -87,6 +87,16 @@ impl MessageLog for FailingMessageLog {
   {
     Ok(0)
   }
+
+  fn last_durable_seq(&self) -> u64 {
+    0
+  }
+
+  fn switch_to_fifo_mode(&self) {}
+
+  async fn evict_below(&self, _seq: u64) -> anyhow::Result<()> {
+    Ok(())
+  }
 }
 
 /// A message log factory that produces `FailingMessageLog` instances sharing a single failure flag.
@@ -110,7 +120,11 @@ impl FailingMessageLogFactory {
 impl MessageLogFactory for FailingMessageLogFactory {
   type Log = FailingMessageLog;
 
-  async fn create(&self, _handler: &StringAtom) -> anyhow::Result<FailingMessageLog> {
+  async fn create(
+    &self,
+    _handler: &StringAtom,
+    _mode: narwhal_server::channel::store::LogMode,
+  ) -> anyhow::Result<FailingMessageLog> {
     Ok(FailingMessageLog { should_fail: self.should_fail.clone() })
   }
 }
@@ -122,6 +136,7 @@ struct StoredChannel {
   config: ChannelConfig,
   acl: ChannelAcl,
   members: Vec<Nid>,
+  channel_type: ChannelType,
 }
 
 /// An in-memory channel store for integration tests.
@@ -146,6 +161,7 @@ impl ChannelStore for InMemoryChannelStore {
       config: channel.config.clone(),
       acl: channel.acl.clone(),
       members: channel.members.iter().cloned().collect(),
+      channel_type: channel.channel_type,
     };
     self.channels.lock().await.insert(handler.clone(), stored);
     Ok(handler)
@@ -170,6 +186,7 @@ impl ChannelStore for InMemoryChannelStore {
       config: stored.config.clone(),
       acl: stored.acl.clone(),
       members: Rc::from(stored.members.clone()),
+      channel_type: stored.channel_type,
     })
   }
 }

--- a/docs/architecture/channels/fifo-channels.md
+++ b/docs/architecture/channels/fifo-channels.md
@@ -248,7 +248,9 @@ While a channel is FIFO:
 - `HISTORY` and `CHAN_SEQ` are rejected (`WRONG_TYPE`); destructive consumption
   has no archive contract.
 - `PUSH` and `POP` are valid.
-- `MEMBER_JOINED` / `MEMBER_LEFT` events still fire on JOIN/LEAVE.
+- `MEMBER_JOINED` fires on JOIN. `MEMBER_LEFT` fires on **non-owner** LEAVE.
+  Owner LEAVE on a FIFO channel emits `CHANNEL_DELETED` instead of
+  `MEMBER_LEFT` (see "Owner LEAVE auto-deletes" below).
 - `MESSAGE` is **never** pushed; `PUSH` does not fan out to subscribers.
   Consumers must explicitly `POP`.
 - Owner `LEAVE` on a FIFO channel **auto-deletes the channel**: the existing

--- a/docs/architecture/channels/fifo-channels.md
+++ b/docs/architecture/channels/fifo-channels.md
@@ -251,10 +251,14 @@ While a channel is FIFO:
 - `MEMBER_JOINED` / `MEMBER_LEFT` events still fire on JOIN/LEAVE.
 - `MESSAGE` is **never** pushed; `PUSH` does not fan out to subscribers.
   Consumers must explicitly `POP`.
-- The owner cannot `LEAVE` (returns `OWNER_CANNOT_LEAVE`). The only way out is
-  `DELETE`. (Because the owner is always a member, the existing pub/sub
-  auto-delete-on-empty path can never fire on a FIFO channel; the channel
-  persists until explicit `DELETE`.)
+- Owner `LEAVE` on a FIFO channel **auto-deletes the channel**: the existing
+  `DELETE` machinery runs (`CHANNEL_DELETED` to all other JOINed members,
+  flush-and-cleanup of cursor, segments, metadata, release of all membership
+  slots), and the leaving owner receives `LEAVE_ACK`. An ownerless FIFO is
+  structurally useless because `PUSH` is owner-only and ownership is
+  immutable, so the channel has no productive lifetime past the owner
+  leaving. Clients must therefore treat `LEAVE` on a FIFO they own as
+  destructive.
 
 ### Destroying a FIFO Channel
 
@@ -414,7 +418,6 @@ Added to `narwhal-protocol`:
 | ------------------ | ----------------------------------------------------------------- |
 | `QUEUE_EMPTY`       | `POP` against an empty FIFO channel.                              |
 | `QUEUE_FULL`        | `PUSH` against a full FIFO channel (at `max_persist_messages`).   |
-| `OWNER_CANNOT_LEAVE` | `LEAVE` issued by the owner of a FIFO channel.                    |
 | `WRONG_TYPE`        | Operation incompatible with channel type (e.g. `BROADCAST` on FIFO, `PUSH` on pub/sub). |
 | `CURSOR_RECOVERY_REQUIRED` | `PUSH` / `POP` / `GET_CHAN_LEN` on a FIFO channel whose head cursor is missing or corrupt; awaiting operator action. |
 
@@ -426,7 +429,7 @@ Added to `narwhal-protocol`:
 | Op             | Pub/Sub                       | FIFO                          |
 | -------------- | ----------------------------- | ----------------------------- |
 | `JOIN`         | Anyone (subject to join ACL)  | Anyone (subject to join ACL)  |
-| `LEAVE`        | Any member                    | Members ✓ / **Owner ✗**       |
+| `LEAVE`        | Any member                    | Any member; **owner LEAVE auto-deletes the channel** |
 | `BROADCAST`    | Members (subject to publish ACL) | **Rejected (`WRONG_TYPE`)** |
 | `MESSAGE`      | Sent to read-ACL members      | Never sent                    |
 | `HISTORY`      | Members (subject to read ACL) | **Rejected (`WRONG_TYPE`)**    |
@@ -713,9 +716,9 @@ The following pub/sub paths must branch on channel type:
 
 | Path                                  | Pub/Sub                          | FIFO                                |
 | ------------------------------------- | -------------------------------- | ----------------------------------- |
-| `LEAVE` handler (manager.rs)          | Removes member; clears owner if owner leaves; auto-deletes channel if last member | Returns `OWNER_CANNOT_LEAVE` if owner; otherwise removes member. Auto-delete-on-empty is implicitly unreachable since the owner is always a member. |
-| `remove_member` (manager.rs)          | Clears `owner` if owner is the leaver | Never reached for owner; LEAVE rejects upstream |
-| Empty-channel auto-delete sites (manager.rs) | Removes channel | Unreachable for FIFO (precondition `member_count == 0` cannot be met). Defensive type-gate is optional. |
+| `LEAVE` handler (manager.rs)          | Removes member; clears owner if owner leaves; auto-deletes channel if last member | Owner LEAVE invokes the DELETE machinery (CHANNEL_DELETED to other members, cursor + segments + metadata cleanup); leaver receives `LEAVE_ACK`. Non-owner LEAVE removes member as in pub/sub. |
+| `remove_member` (manager.rs)          | Clears `owner` if owner is the leaver | Not reached for owner on FIFO (owner LEAVE auto-deletes before reaching this path); non-owner path matches pub/sub |
+| Empty-channel auto-delete sites (manager.rs) | Removes channel | Reused: a non-owner LEAVE that empties the channel still triggers cleanup (with the spec-deviation auto-delete-on-owner-LEAVE handling the owner case earlier). |
 | Message log eviction policy           | Tail-evict at cap                | Reject PUSH at cap (`QUEUE_FULL`)    |
 | `BROADCAST` handler                   | Append + fan out                 | `WRONG_TYPE`                         |
 | `HISTORY` / `CHAN_SEQ` handlers       | Read from log                    | `WRONG_TYPE`                         |
@@ -839,8 +842,8 @@ A non-binding outline of the work units. Order is suggestive, not prescriptive.
      message variants. `Push` and `PopAck` carry `length` like `Broadcast` /
      `Message` and a binary payload.
    - Add `EventKind::ChannelReconfigured`.
-   - Add error reasons: `QUEUE_EMPTY`, `QUEUE_FULL`, `OWNER_CANNOT_LEAVE`,
-     `WRONG_TYPE`, `CURSOR_RECOVERY_REQUIRED`.
+   - Add error reasons: `QUEUE_EMPTY`, `QUEUE_FULL`, `WRONG_TYPE`,
+     `CURSOR_RECOVERY_REQUIRED`.
    - Update serialize/deserialize/validate/test fixtures.
 2. **Channel manager (`crates/server/src/channel/manager.rs`):**
    - Add `Channel.channel_type: ChannelType` and `Channel.cursor` (head seq).
@@ -857,9 +860,11 @@ A non-binding outline of the work units. Order is suggestive, not prescriptive.
      then `SET_CHAN_CONFIG_ACK` sent. A crash before metadata is
      written must leave the channel as pub/sub (a stranded
      `cursor.bin` is acceptable; pub/sub ignores it).
-   - Implement type-aware branches in `LEAVE` (reject for owner with
-     `OWNER_CANNOT_LEAVE`), `BROADCAST`, `HISTORY` / `CHAN_SEQ` (all return
-     `WRONG_TYPE`).
+   - Implement type-aware branches: `LEAVE` for owner on a FIFO channel
+     auto-deletes via the existing DELETE machinery (CHANNEL_DELETED to
+     other members, cleanup of cursor/segments/metadata) and replies
+     `LEAVE_ACK`; `BROADCAST` and `HISTORY` / `CHAN_SEQ` all return
+     `WRONG_TYPE`.
    - Emit `CHANNEL_RECONFIGURED` from `set_channel_configuration` after a
      successful change.
 3. **Message log (`crates/server/src/...message_log...`):**

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -521,6 +521,8 @@ LEAVE_ACK id=2
 
 **Disconnect behavior**: When a user's last connection disconnects, the server automatically removes them from all **transient** (non-persistent) channels. Membership in **persistent** channels (`persist=true`) is preserved across disconnects; users remain members until they explicitly leave or are removed by the channel owner. Without authentication, all channel memberships are always cleaned up on disconnect regardless of the persistence flag.
 
+**FIFO channels**: If the owner of a FIFO channel issues `LEAVE` against it, the server treats it as a channel deletion. The channel is destroyed, a `CHANNEL_DELETED` event is sent to every other member, and the caller receives a `LEAVE_ACK` (not a `DELETE_ACK`).
+
 ---
 
 ### DELETE
@@ -575,6 +577,9 @@ Sends a message to all members of a channel. This message includes a payload.
 BROADCAST id=3 channel=!42@example.com qos=1 length=1024
 [1024 bytes of binary payload follow]
 ```
+
+**Notes**:
+- `BROADCAST` is only valid on `pubsub` channels. On a `fifo` channel the server returns [ERROR](#error) with `WRONG_TYPE`.
 
 ---
 
@@ -885,10 +890,13 @@ Returns the configuration for a channel.
 - `max_persist_messages` (u32, required): Maximum number of messages to persist for this channel (0 = no limit configured)
 - `persist` (bool, required): Whether message persistence is enabled for this channel
 - `message_flush_interval` (u32, required): Interval in milliseconds between periodic message log flushes (0 = flush immediately after each append)
+- `type` (string, required): Channel type (must be non-empty). One of:
+  - `pubsub`: pub/sub channel (default for newly created channels); `BROADCAST` fans out to all members and `HISTORY`/`CHAN_SEQ` are available when persistence is enabled.
+  - `fifo`: FIFO work-queue channel; the data plane uses PUSH/POP/GET_CHAN_LEN. `BROADCAST`, `HISTORY`, and `CHAN_SEQ` return [ERROR](#error) with `WRONG_TYPE` on FIFO channels.
 
 **Example**:
 ```
-CHAN_CONFIG id=9 channel=!42@example.com max_clients=100 max_payload_size=1048576 max_persist_messages=50 message_flush_interval=5000 persist=true
+CHAN_CONFIG id=9 channel=!42@example.com max_clients=100 max_payload_size=1048576 max_persist_messages=50 message_flush_interval=5000 persist=true type=pubsub
 ```
 
 ---
@@ -907,10 +915,22 @@ Sets the configuration for a channel. Only the channel owner can modify configur
 - `max_persist_messages` (u32, optional): Maximum number of messages to persist for this channel
 - `persist` (bool, optional): Whether message persistence is enabled for this channel
 - `message_flush_interval` (u32, optional): Interval in milliseconds between periodic message log flushes (0 = flush immediately after each append)
+- `type` (string, optional): Requested channel type. Accepted values are `pubsub` and `fifo`; any other value is rejected with `BAD_REQUEST`. Omitting the field leaves the type unchanged.
+
+**Type Transitions**:
+- Newly created channels are always `pubsub`. A channel becomes `fifo` only through a `SET_CHAN_CONFIG type=fifo` transition issued by the owner.
+- The transition is one-way: requesting `type=pubsub` on a channel that is already `fifo` is rejected with `BAD_REQUEST`.
+- Transitioning to `fifo` requires `persist=true` and `max_persist_messages > 0` on the resulting configuration (combining the merged values with any unchanged fields). Otherwise the request is rejected with `BAD_REQUEST`.
+- On success, the server emits a [CHANNEL_RECONFIGURED](#event-kinds) event to the other channel members before sending the `SET_CHAN_CONFIG_ACK`.
 
 **Example**:
 ```
 SET_CHAN_CONFIG id=10 channel=!42@example.com max_clients=200 max_payload_size=2097152 message_flush_interval=5000 persist=true
+```
+
+**Example (transition to FIFO)**:
+```
+SET_CHAN_CONFIG id=11 channel=!42@example.com type=fifo persist=true max_persist_messages=1000
 ```
 
 **Response**: [SET_CHAN_CONFIG_ACK](#set_chan_config_ack) or [ERROR](#error)
@@ -952,6 +972,7 @@ CHAN_SEQ id=11 channel=!42@example.com
 
 **Notes**:
 - The server requires the caller to be a member of the channel, to have `read` permission in the channel ACL, and for persistence to be enabled on the channel. Otherwise an [ERROR](#error) with `USER_NOT_IN_CHANNEL`, `NOT_ALLOWED`, or `PERSISTENCE_NOT_ENABLED` is returned.
+- `CHAN_SEQ` is only valid on `pubsub` channels. On a `fifo` channel the server returns [ERROR](#error) with `WRONG_TYPE`.
 
 ---
 
@@ -998,6 +1019,7 @@ HISTORY id=12 channel=!42@example.com from_seq=50 history_id=h1 limit=10
 
 **Notes**:
 - The server requires the caller to be a member of the channel, to have `read` permission in the channel ACL, and for persistence to be enabled on the channel. Otherwise an [ERROR](#error) with `USER_NOT_IN_CHANNEL`, `NOT_ALLOWED`, or `PERSISTENCE_NOT_ENABLED` is returned.
+- `HISTORY` is only valid on `pubsub` channels. On a `fifo` channel the server returns [ERROR](#error) with `WRONG_TYPE`.
 - Requests for a non-local `channel` domain return `NOT_IMPLEMENTED`.
 
 ---
@@ -1371,6 +1393,7 @@ The following error reasons can be returned in [ERROR](#error) messages:
 | `BAD_REQUEST` | The request is malformed or contains invalid parameters |
 | `CHANNEL_NOT_FOUND` | The specified channel does not exist |
 | `CHANNEL_IS_FULL` | The channel has reached its maximum capacity |
+| `CURSOR_RECOVERY_REQUIRED` | A FIFO data-plane operation was rejected because the channel's head cursor failed recovery; the operator must restore `cursor.bin`, write a fresh sidecar, or DELETE the channel before normal operation can resume |
 | `FORBIDDEN` | The request is not allowed due to lack of permissions |
 | `INTERNAL_SERVER_ERROR` | An unexpected error occurred on the server |
 | `NOT_ALLOWED` | The operation is not allowed for the current user or context |
@@ -1378,6 +1401,8 @@ The following error reasons can be returned in [ERROR](#error) messages:
 | `OUTBOUND_QUEUE_FULL` | The connection's outbound queue is full and cannot accept new messages |
 | `PERSISTENCE_NOT_ENABLED` | The target channel does not have message persistence enabled |
 | `POLICY_VIOLATION` | The request violates server policies or rules |
+| `QUEUE_EMPTY` | A `POP` was attempted on an empty FIFO channel queue |
+| `QUEUE_FULL` | A `PUSH` was attempted on a FIFO channel whose queue is at `max_persist_messages` |
 | `RESOURCE_LIMIT_REACHED` | A server-wide resource limit has been reached (e.g., maximum number of channels) |
 | `RESPONSE_TOO_LARGE` | The response exceeds the maximum message size limit |
 | `SERVER_OVERLOADED` | The server is overloaded and cannot handle the request |
@@ -1390,16 +1415,20 @@ The following error reasons can be returned in [ERROR](#error) messages:
 | `USER_NOT_IN_CHANNEL` | The user is not a member of the specified channel |
 | `USERNAME_IN_USE` | The requested username is already taken |
 | `USER_NOT_REGISTERED` | The user has not completed the registration process |
+| `WRONG_TYPE` | The requested operation is not allowed for the channel's declared type (e.g. `BROADCAST` on a FIFO channel, `PUSH` on a pub/sub channel) |
 
 ### Recoverable vs Non-Recoverable Errors
 
 **Recoverable errors** (client can retry or take corrective action):
 - `CHANNEL_IS_FULL`
 - `CHANNEL_NOT_FOUND`
+- `CURSOR_RECOVERY_REQUIRED`
 - `FORBIDDEN`
 - `NOT_ALLOWED`
 - `NOT_IMPLEMENTED`
 - `PERSISTENCE_NOT_ENABLED`
+- `QUEUE_EMPTY`
+- `QUEUE_FULL`
 - `RESOURCE_LIMIT_REACHED`
 - `RESPONSE_TOO_LARGE`
 - `SERVER_OVERLOADED`
@@ -1407,6 +1436,7 @@ The following error reasons can be returned in [ERROR](#error) messages:
 - `USER_NOT_IN_CHANNEL`
 - `USERNAME_IN_USE`
 - `USER_NOT_REGISTERED`
+- `WRONG_TYPE`
 
 **Non-recoverable errors** (connection should be closed):
 - `BAD_REQUEST`
@@ -1444,6 +1474,7 @@ The following event kinds can be sent in [EVENT](#event) and [S2M_FORWARD_EVENT]
 | `MEMBER_JOINED` | A member has joined a channel |
 | `MEMBER_LEFT` | A member has left a channel |
 | `CHANNEL_DELETED` | A channel has been deleted by its owner |
+| `CHANNEL_RECONFIGURED` | A channel's configuration has changed |
 
 ### Event Context
 
@@ -1452,6 +1483,7 @@ Events contain contextual information that varies depending on the event kind:
 - **MEMBER_JOINED**: Includes `channel`, `nid` (the member who joined), and `owner` (whether they are the channel owner)
 - **MEMBER_LEFT**: Includes `channel`, `nid` (the member who left), and `owner` (whether they were the channel owner)
 - **CHANNEL_DELETED**: Includes `channel` (the channel that was deleted). No `nid` or `owner` fields are set.
+- **CHANNEL_RECONFIGURED**: Includes `channel` (the channel whose configuration changed). No `nid` or `owner` fields are set. Fires after any successful [SET_CHAN_CONFIG](#set_chan_config) that actually changes the configuration (including the pub/sub to FIFO transition). The event is delivered to every other channel member; the originating client receives the `SET_CHAN_CONFIG_ACK` instead. Clients should re-issue [GET_CHAN_CONFIG](#get_chan_config) to read the new configuration.
 
 ## Protocol Flow Examples
 


### PR DESCRIPTION
## Summary

PR 1 of two for [FIFO Channels](../blob/main/docs/architecture/channels/fifo-channels.md). Ships the transition slice: a pub/sub channel can be promoted to a FIFO work-queue via `SET_CHAN_CONFIG type=fifo`, the transition is crash-safe and survives restart, and FIFO-specific behavior overrides (`WRONG_TYPE` on `BROADCAST`/`HISTORY`/`CHAN_SEQ`; owner-`LEAVE` auto-deletes the channel) are wired up.

The data plane (`PUSH`/`POP`/`GET_CHAN_LEN`), FIFO metrics, failure-mode tests, and the `protocol.md` update ship in PR 2. FIFO is not production-ready until that lands.

## What changed

- **Protocol** (`crates/protocol`):
  - New `ErrorReason`s: `QUEUE_EMPTY`, `QUEUE_FULL`, `WRONG_TYPE`, `CURSOR_RECOVERY_REQUIRED`
  - New `EventKind::ChannelReconfigured` (fires on any successful `CHAN_CONFIG` change, suppressed on no-op)
  - `type` field on `SET_CHAN_CONFIG` (optional, partial-update) and `CHAN_CONFIG` (required, read response)

- **Persistence** (`crates/server/src/channel/store.rs`):
  - `ChannelType { PubSub, Fifo }` appended to `PersistedChannel` (schema break, no migration: pre-prod)
  - New `MessageLog` trait methods: `last_durable_seq()`, `switch_to_fifo_mode()`, `evict_below(seq)` (with tail-segment-retention invariant)
  - `LogMode` enum threaded through `MessageLogFactory::create()`; new `channel_dir(handler)` method so the manager can locate the FIFO cursor sidecar

- **`FifoCursor` module** (`crates/server/src/channel/fifo_cursor.rs`, new file):
  - 16-byte sidecar: `next_seq` u64-LE + crc32 + 4-byte zero pad
  - `write_initial` / `load` / `advance` / `delete` via `compio::fs` and the existing `atomic_write` helper
  - 5-rule recovery validation per the spec

- **Channel manager** (`crates/server/src/channel/manager.rs`):
  - `kind: ChannelKind` field on `Channel` with `PubSub` / `Fifo(FifoState::{Healthy(FifoCursor), NeedsRecovery})`
  - `restore()` loads cursor for FIFO channels and surfaces failures as `NeedsRecovery` (channel stays in namespace; FIFO ops will return `CURSOR_RECOVERY_REQUIRED` once PR 2 wires them)
  - Crash-safe transition order in `set_channel_configuration`: `log.flush()` → `cursor.write_initial()` → `store.save_channel()` → in-memory mutations → `CHANNEL_RECONFIGURED` → `SET_CHAN_CONFIG_ACK`
  - Inline `WRONG_TYPE` branches in `broadcast_payload` / `history` / `channel_seq`
  - Owner `LEAVE` on FIFO branches to a refactored `do_delete_channel` helper (CHANNEL_DELETED to others, `LEAVE_ACK` to leaver, cursor.bin removed)

- **Spec** (`docs/architecture/channels/fifo-channels.md`):
  - Updated for the owner-`LEAVE`-deletes deviation: removed `OWNER_CANNOT_LEAVE` from error tables, replaced the bullet under "Living as a FIFO Channel," updated the authorization matrix and behavior-overrides table.

## Spec deviation

The original spec had owner `LEAVE` returning `OWNER_CANNOT_LEAVE`. PR 1 instead **auto-deletes the channel** when the owner LEAVEs a FIFO channel, since an ownerless FIFO is structurally useless (PUSH is owner-only and ownership is immutable). The leaving owner receives `LEAVE_ACK` (matches the request shape); other members receive `CHANNEL_DELETED`. The error reason `OWNER_CANNOT_LEAVE` is therefore not added to the protocol.

## What's next (PR 2)

`Command::Push` / `Command::Pop` / `Command::GetChannelLen`, c2s dispatch arms, FIFO metrics (`fifo_pushes`/`fifo_pops`/`fifo_queue_depth`/`fifo_cursor_fsync_seconds`), test-only fault injection for crash-during-POP, failure-mode tests in `c2s_fifo_channel_failure.rs`, and the `docs/protocol.md` update.

## Test plan

- [x] `cargo build --workspace` clean (no warnings)
- [x] `cargo test --workspace` — all existing tests still pass
- [x] 5 new inline tests in `file_message_log.rs` covering `last_durable_seq`, `switch_to_fifo_mode`, `evict_below` (drop-with-retention, no-op in pubsub mode, no-op on `seq=0`)
- [x] 8 new inline tests in `fifo_cursor.rs` covering encode/decode round-trip, atomic-write, delete idempotence, and all 5 recovery validation cases
- [x] 11 new integration tests in `crates/server/tests/c2s_fifo_channel.rs` covering transition validation, restart-preserves-type, `WRONG_TYPE` branches, owner-LEAVE-deletes, and `CHANNEL_RECONFIGURED` (fires on type change / config-only change / suppressed on no-op)
- [x] One existing test (`test_c2s_modulator_keep_persistent_channels_on_disconnect`) updated to consume the new `CHANNEL_RECONFIGURED` event the persist toggle now emits