### PR TITLE
feat(server): FIFO channels CLEAR command (PR 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Narwhal will be documented in this file.
 
 ## Unreleased
 
-* [ENHANCEMENT]: Add support for FIFO-type channels with at-most-once delivery via `PUSH` / `POP` / `GET_CHAN_LEN`. [#292](https://github.com/ortuman/narwhal/pull/292), [#298](https://github.com/ortuman/narwhal/pull/298)
+* [ENHANCEMENT]: Add support for FIFO-type channels with at-most-once delivery via `PUSH` / `POP` / `GET_CHAN_LEN` / `CLEAR`. [#292](https://github.com/ortuman/narwhal/pull/292), [#298](https://github.com/ortuman/narwhal/pull/298), [#299](https://github.com/ortuman/narwhal/pull/299)
 
 ## 0.6.1 (2026-05-01)
 

--- a/crates/client/src/compio/c2s.rs
+++ b/crates/client/src/compio/c2s.rs
@@ -501,6 +501,30 @@ impl C2sClient {
     }
   }
 
+  /// Discards every element currently queued on a FIFO channel without
+  /// destroying it. Owner-only, idempotent, and the recovery path out of a
+  /// `CURSOR_RECOVERY_REQUIRED` state.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the channel is not FIFO, the caller is not a
+  /// member, or the caller is not the owner.
+  pub async fn clear(&self, channel: StringAtom) -> crate::Result<()> {
+    use narwhal_protocol::ClearParameters;
+
+    let id = self.client.next_id().await;
+    let message = Message::Clear(ClearParameters { id, channel });
+
+    let handle = self.client.send_message(message, None).await?;
+    let (response, _) = handle.response().await?;
+
+    match response {
+      Message::ClearAck(_) => Ok(()),
+      Message::Error(err) => Err(err.into()),
+      _ => Err(anyhow!("unexpected response to clear request").into()),
+    }
+  }
+
   /// Shuts down the client and closes all connections.
   ///
   /// This method gracefully shuts down the client, signalling cancellation to

--- a/crates/client/src/tokio/c2s.rs
+++ b/crates/client/src/tokio/c2s.rs
@@ -511,6 +511,30 @@ impl C2sClient {
     }
   }
 
+  /// Discards every element currently queued on a FIFO channel without
+  /// destroying it. Owner-only, idempotent, and the recovery path out of a
+  /// `CURSOR_RECOVERY_REQUIRED` state.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the channel is not FIFO, the caller is not a
+  /// member, or the caller is not the owner.
+  pub async fn clear(&self, channel: StringAtom) -> crate::Result<()> {
+    use narwhal_protocol::ClearParameters;
+
+    let id = self.client.next_id().await;
+    let message = Message::Clear(ClearParameters { id, channel });
+
+    let handle = self.client.send_message(message, None).await?;
+    let (response, _) = handle.await.map_err(anyhow::Error::from)??;
+
+    match response {
+      Message::ClearAck(_) => Ok(()),
+      Message::Error(err) => Err(err.into()),
+      _ => Err(anyhow!("unexpected response to clear request").into()),
+    }
+  }
+
   /// Shuts down the client and closes all connections.
   ///
   /// This method gracefully shuts down the client, closing all active connections

--- a/crates/protocol/src/message.rs
+++ b/crates/protocol/src/message.rs
@@ -42,6 +42,8 @@ pub enum Message {
   BroadcastAck(BroadcastAckParameters),
   ChannelAcl(ChannelAclParameters),
   ChannelConfiguration(ChannelConfigurationParameters),
+  Clear(ClearParameters),
+  ClearAck(ClearAckParameters),
   Connect(ConnectParameters),
   ConnectAck(ConnectAckParameters),
   DeleteChannel(DeleteChannelParameters),
@@ -167,6 +169,21 @@ pub struct ChannelConfigurationParameters {
 
   #[param(name = "type", validate = "non_empty")]
   pub r#type: StringAtom,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, ProtocolMessageParameters)]
+pub struct ClearParameters {
+  #[param(validate = "non_zero")]
+  pub id: u32,
+
+  #[param(validate = "non_empty")]
+  pub channel: StringAtom,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, ProtocolMessageParameters)]
+pub struct ClearAckParameters {
+  #[param(validate = "non_zero")]
+  pub id: u32,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, ProtocolMessageParameters)]
@@ -738,6 +755,8 @@ impl Message {
       b"CONNECT_ACK" => Ok(Message::ConnectAck(ConnectAckParameters::default())),
       b"CHAN_ACL" => Ok(Message::ChannelAcl(ChannelAclParameters::default())),
       b"CHAN_CONFIG" => Ok(Message::ChannelConfiguration(ChannelConfigurationParameters::default())),
+      b"CLEAR" => Ok(Message::Clear(ClearParameters::default())),
+      b"CLEAR_ACK" => Ok(Message::ClearAck(ClearAckParameters::default())),
       b"DELETE" => Ok(Message::DeleteChannel(DeleteChannelParameters::default())),
       b"DELETE_ACK" => Ok(Message::DeleteChannelAck(DeleteChannelAckParameters::default())),
       b"ERROR" => Ok(Message::Error(ErrorParameters::default())),
@@ -807,6 +826,8 @@ impl Message {
       Message::ConnectAck { .. } => "CONNECT_ACK",
       Message::ChannelAcl { .. } => "CHAN_ACL",
       Message::ChannelConfiguration { .. } => "CHAN_CONFIG",
+      Message::Clear { .. } => "CLEAR",
+      Message::ClearAck { .. } => "CLEAR_ACK",
       Message::DeleteChannel { .. } => "DELETE",
       Message::DeleteChannelAck { .. } => "DELETE_ACK",
       Message::Error { .. } => "ERROR",
@@ -873,6 +894,8 @@ impl Message {
       ConnectAck(params) => params.encode(parameter_writer),
       ChannelAcl(params) => params.encode(parameter_writer),
       ChannelConfiguration(params) => params.encode(parameter_writer),
+      Clear(params) => params.encode(parameter_writer),
+      ClearAck(params) => params.encode(parameter_writer),
       DeleteChannel(params) => params.encode(parameter_writer),
       DeleteChannelAck(params) => params.encode(parameter_writer),
       Error(params) => params.encode(parameter_writer),
@@ -936,6 +959,8 @@ impl Message {
       BroadcastAck(params) => params.decode(parameter_reader),
       ChannelAcl(params) => params.decode(parameter_reader),
       ChannelConfiguration(params) => params.decode(parameter_reader),
+      Clear(params) => params.decode(parameter_reader),
+      ClearAck(params) => params.decode(parameter_reader),
       Connect(params) => params.decode(parameter_reader),
       ConnectAck(params) => params.decode(parameter_reader),
       DeleteChannel(params) => params.decode(parameter_reader),
@@ -1014,6 +1039,8 @@ impl Message {
         Ok(())
       },
       ChannelConfiguration(params) => params.validate(),
+      Clear(params) => params.validate(),
+      ClearAck(params) => params.validate(),
       Connect(params) => params.validate(),
       ConnectAck(params) => params.validate(),
       DeleteChannel(params) => params.validate(),
@@ -1129,6 +1156,8 @@ impl Message {
       Message::BroadcastAck(params) => Some(params.id),
       Message::ChannelAcl(params) => Some(params.id),
       Message::ChannelConfiguration(params) => Some(params.id),
+      Message::Clear(params) => Some(params.id),
+      Message::ClearAck(params) => Some(params.id),
       Message::DeleteChannel(params) => Some(params.id),
       Message::DeleteChannelAck(params) => Some(params.id),
       Message::GetChannelAcl(params) => Some(params.id),
@@ -1250,6 +1279,18 @@ mod tests {
   #[test]
   fn channel_len_round_trip() {
     let original = Message::ChannelLen(ChannelLenParameters { id: 9, channel: "!c@localhost".into(), count: 42 });
+    assert_eq!(roundtrip(original.clone()), original);
+  }
+
+  #[test]
+  fn clear_round_trip() {
+    let original = Message::Clear(ClearParameters { id: 11, channel: "!c@localhost".into() });
+    assert_eq!(roundtrip(original.clone()), original);
+  }
+
+  #[test]
+  fn clear_ack_round_trip() {
+    let original = Message::ClearAck(ClearAckParameters { id: 11 });
     assert_eq!(roundtrip(original.clone()), original);
   }
 

--- a/crates/server/src/c2s/conn.rs
+++ b/crates/server/src/c2s/conn.rs
@@ -562,6 +562,9 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> C2sDispatcherInner<CS, MLF> {
       Message::GetChannelLen { .. } => {
         self.dispatch_get_channel_len_message(msg).await?;
       },
+      Message::Clear { .. } => {
+        self.dispatch_clear_message(msg).await?;
+      },
       _ => {
         return Err(narwhal_protocol::Error::new(UnexpectedMessage).into());
       },
@@ -1280,6 +1283,27 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> C2sDispatcherInner<CS, MLF> {
       nid = nid.to_string(),
       channel = channel_id.to_string(),
       "channel len requested"
+    );
+
+    Ok(())
+  }
+
+  async fn dispatch_clear_message(&mut self, msg: Message) -> anyhow::Result<()> {
+    let Message::Clear(params) = msg else { unreachable!() };
+
+    let correlation_id = params.id;
+    let channel_id = Self::parse_channel_id(&params.channel)?;
+
+    let nid = self.nid.as_ref().unwrap().clone();
+    let transmitter = self.transmitter.clone();
+
+    self.channel_manager.clear(channel_id.clone(), nid.clone(), transmitter, correlation_id).await?;
+
+    trace!(
+      handler = self.transmitter.handler,
+      nid = nid.to_string(),
+      channel = channel_id.to_string(),
+      "fifo channel cleared"
     );
 
     Ok(())

--- a/crates/server/src/channel/manager.rs
+++ b/crates/server/src/channel/manager.rs
@@ -18,7 +18,7 @@ use narwhal_protocol::ErrorReason::{
 };
 use narwhal_protocol::{
   AclAction, AclType, BroadcastAckParameters, ChannelAclParameters, ChannelConfigurationParameters,
-  ChannelLenParameters, ChannelSeqAckParameters, DeleteChannelAckParameters, HistoryAckParameters,
+  ChannelLenParameters, ChannelSeqAckParameters, ClearAckParameters, DeleteChannelAckParameters, HistoryAckParameters,
   JoinChannelAckParameters, LeaveChannelAckParameters, ListChannelsAckParameters, ListMembersAckParameters, Message,
   MessageParameters, PopAckParameters, PushAckParameters, QoS, SetChannelAclAckParameters,
   SetChannelConfigurationAckParameters,
@@ -99,6 +99,7 @@ struct ChannelManagerMetrics {
   message_log_deletes: Family<ResultLabel, Counter>,
   fifo_pushes: Family<ResultLabel, Counter>,
   fifo_pops: Family<ResultLabel, Counter>,
+  fifo_clears: Family<ResultLabel, Counter>,
   fifo_cursor_fsync_seconds: Histogram,
 }
 
@@ -171,6 +172,8 @@ impl ChannelManagerMetrics {
     registry.register("fifo_pushes", "FIFO PUSH outcomes", fifo_pushes.clone());
     let fifo_pops = Family::default();
     registry.register("fifo_pops", "FIFO POP outcomes", fifo_pops.clone());
+    let fifo_clears = Family::default();
+    registry.register("fifo_clears", "FIFO CLEAR outcomes", fifo_clears.clone());
     let fifo_cursor_fsync_seconds =
       Histogram::new(prometheus_client::metrics::histogram::exponential_buckets(0.0001, 2.0, 16));
     registry.register(
@@ -197,6 +200,7 @@ impl ChannelManagerMetrics {
       message_log_deletes,
       fifo_pushes,
       fifo_pops,
+      fifo_clears,
       fifo_cursor_fsync_seconds,
     }
   }
@@ -373,6 +377,13 @@ enum Command {
     reply_tx: Sender<anyhow::Result<()>>,
   },
   GetChannelLen {
+    channel_id: ChannelId,
+    nid: Nid,
+    transmitter: Arc<dyn Transmitter>,
+    correlation_id: u32,
+    reply_tx: Sender<anyhow::Result<()>>,
+  },
+  Clear {
     channel_id: ChannelId,
     nid: Nid,
     transmitter: Arc<dyn Transmitter>,
@@ -789,6 +800,10 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
       },
       Command::GetChannelLen { channel_id, nid, transmitter, correlation_id, reply_tx } => {
         let result = self.get_channel_len(channel_id, nid, transmitter, correlation_id);
+        let _ = reply_tx.send(result).await;
+      },
+      Command::Clear { channel_id, nid, transmitter, correlation_id, reply_tx } => {
+        let result = self.clear(channel_id, nid, transmitter, correlation_id).await;
         let _ = reply_tx.send(result).await;
       },
     }
@@ -2167,6 +2182,92 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelShard<CS, MLF> {
     Ok(())
   }
 
+  /// CLEAR handler. Owner-only, idempotent, and the recovery path out of
+  /// `NeedsRecovery`. Discards every queued element by flushing the log and
+  /// writing a fresh `cursor.bin` whose `next_seq = log.last_seq() + 1`.
+  /// Membership, ACLs, configuration, and seq monotonicity are preserved
+  /// (no reset to 1). Exempt from `CURSOR_RECOVERY_REQUIRED` since this is
+  /// the operator-less heal for that state.
+  async fn clear(
+    &mut self,
+    channel_id: ChannelId,
+    nid: Nid,
+    transmitter: Arc<dyn Transmitter>,
+    correlation_id: u32,
+  ) -> anyhow::Result<()> {
+    if channel_id.domain != self.local_domain {
+      self.metrics.fifo_clears.get_or_create(&FIFO_NOT_IMPLEMENTED).inc();
+      return Err(narwhal_protocol::Error::new(NotImplemented).with_id(correlation_id).into());
+    }
+
+    let Some(channel) = self.channels.get_mut(&channel_id.handler) else {
+      self.metrics.fifo_clears.get_or_create(&FIFO_CHANNEL_NOT_FOUND).inc();
+      return Err(narwhal_protocol::Error::new(ChannelNotFound).with_id(correlation_id).into());
+    };
+
+    if matches!(&channel.kind, ChannelKind::PubSub) {
+      self.metrics.fifo_clears.get_or_create(&FIFO_WRONG_TYPE).inc();
+      return Err(narwhal_protocol::Error::new(WrongType).with_id(correlation_id).into());
+    }
+
+    if !channel.is_member(&nid) {
+      self.metrics.fifo_clears.get_or_create(&FIFO_USER_NOT_IN_CHANNEL).inc();
+      return Err(narwhal_protocol::Error::new(UserNotInChannel).with_id(correlation_id).into());
+    }
+
+    if !channel.is_owner(&nid) {
+      self.metrics.fifo_clears.get_or_create(&FIFO_FORBIDDEN).inc();
+      return Err(narwhal_protocol::Error::new(Forbidden).with_id(correlation_id).into());
+    }
+
+    // Step 1: synchronously flush + fsync the log so `log.last_seq()` is
+    // anchored on disk. The cursor we are about to write must point past
+    // a durable tail; otherwise a crash between cursor.bin fsync and the
+    // next log flush would leave `cursor.next_seq > log.last_seq() + 1`,
+    // which the recovery model treats as corruption.
+    let start = Instant::now();
+    let result = channel.message_log.flush().await;
+    self.metrics.record_flush(start, &result);
+    result?;
+
+    // Step 2: atomic-write `cursor.bin` with the new head. Uses the same
+    // crash-safe path as the type-transition write (tmp -> fsync -> rename
+    // -> fsync parent).
+    let new_next_seq = channel.message_log.last_seq().saturating_add(1);
+    let Some(channel_dir) = self.message_log_factory.channel_dir(&channel_id.handler) else {
+      // FIFO requires a persistent message log factory; the absence of a
+      // channel_dir is a configuration error.
+      return Err(narwhal_protocol::Error::new(InternalServerError).with_id(correlation_id).into());
+    };
+    let start = Instant::now();
+    let new_cursor = FifoCursor::write_initial(channel_dir, new_next_seq).await;
+    self.metrics.fifo_cursor_fsync_seconds.observe(start.elapsed().as_secs_f64());
+    let new_cursor = new_cursor?;
+
+    // Step 3: install the fresh cursor and align channel.seq. `NeedsRecovery`
+    // transitions back to `Healthy` here; an already-`Healthy` channel
+    // replaces its in-memory cursor handle with the freshly written one.
+    channel.kind = ChannelKind::Fifo(FifoState::Healthy(new_cursor));
+    channel.seq = new_next_seq;
+
+    // Step 4: ACK. The client can now resume PUSH/POP on the cleared queue.
+    transmitter.send_message(Message::ClearAck(ClearAckParameters { id: correlation_id }));
+    self.metrics.fifo_clears.get_or_create(&SUCCESS).inc();
+
+    // Step 5: best-effort lazy head-eviction. The cursor now sits past every
+    // sealed segment, so head-eviction can reclaim them all (the tail-segment
+    // retention invariant keeps the active segment around so `log.last_seq()`
+    // stays recoverable). Failures must not propagate: CLEAR already
+    // committed (cursor durable, ACK sent).
+    let log = channel.message_log.clone();
+    let handler = channel_id.handler.clone();
+    if let Err(e) = log.evict_below(new_next_seq).await {
+      warn!(channel = %handler, error = %e, "FIFO head-eviction after CLEAR failed (best-effort)");
+    }
+
+    Ok(())
+  }
+
   /// Best-effort cleanup of persistent storage for a channel (message log + store record).
   /// Errors are logged but never propagated. Callers must not depend on storage cleanup
   /// succeeding for in-memory consistency.
@@ -2912,6 +3013,27 @@ impl<CS: ChannelStore, MLF: MessageLogFactory> ChannelManager<CS, MLF> {
     self.mailboxes[shard]
       .send(Command::GetChannelLen { channel_id, nid, transmitter, correlation_id, reply_tx })
       .await?;
+
+    reply_rx.recv().await?
+  }
+
+  /// CLEAR a FIFO channel. Owner-only, idempotent. Discards every queued
+  /// element without destroying the channel, preserving membership, ACLs,
+  /// configuration, and seq monotonicity. Also the recovery path for a
+  /// channel in `NeedsRecovery` state (exempt from `CURSOR_RECOVERY_REQUIRED`).
+  pub async fn clear(
+    &self,
+    channel_id: ChannelId,
+    nid: Nid,
+    transmitter: Arc<dyn Transmitter>,
+    correlation_id: u32,
+  ) -> anyhow::Result<()> {
+    self.assert_bootstrapped();
+
+    let shard = shard_for(&channel_id.handler, self.mailboxes.len());
+    let (reply_tx, reply_rx) = async_channel::bounded(1);
+
+    self.mailboxes[shard].send(Command::Clear { channel_id, nid, transmitter, correlation_id, reply_tx }).await?;
 
     reply_rx.recv().await?
   }

--- a/crates/server/tests/c2s_fifo_channel.rs
+++ b/crates/server/tests/c2s_fifo_channel.rs
@@ -13,7 +13,7 @@ use narwhal_common::core_dispatcher::CoreDispatcher;
 use narwhal_modulator::create_s2m_listener;
 use narwhal_modulator::modulator::AuthResult;
 use narwhal_protocol::{
-  AclAction, AclType, BroadcastParameters, ChannelSeqParameters, ErrorReason, EventKind,
+  AclAction, AclType, BroadcastParameters, ChannelSeqParameters, ClearParameters, ErrorReason, EventKind,
   GetChannelConfigurationParameters, GetChannelLenParameters, HistoryParameters, LeaveChannelParameters,
   ListChannelsParameters, Message, PopParameters, PushParameters, SetChannelAclParameters,
   SetChannelConfigurationParameters,
@@ -1261,6 +1261,301 @@ async fn test_push_durable_with_zero_flush_interval() -> anyhow::Result<()> {
     suite.auth(TEST_USER_1, TEST_USER_1).await?;
     let (payload, _) = pop_ok(&mut suite, TEST_USER_1, CHANNEL, 10).await?;
     assert_eq!(payload, b"pre-restart");
+
+    suite.teardown().await?;
+    s2m_ln.shutdown().await?;
+    s2m_dispatcher.shutdown().await?;
+  }
+
+  Ok(())
+}
+
+// ---------- PR 3 CLEAR tests ----------
+
+/// Sends a CLEAR and asserts a CLEAR_ACK with the same correlation id.
+async fn clear_ok<CS: ChannelStore, MLF: MessageLogFactory>(
+  suite: &mut C2sSuite<CS, MLF>,
+  user: &str,
+  channel: &str,
+  id: u32,
+) -> anyhow::Result<()> {
+  suite.write_message(user, Message::Clear(ClearParameters { id, channel: StringAtom::from(channel) })).await?;
+  match suite.read_message(user).await? {
+    Message::ClearAck(p) => {
+      assert_eq!(p.id, id);
+      Ok(())
+    },
+    other => panic!("expected ClearAck, got: {:?}", other),
+  }
+}
+
+/// Recursively find every `cursor.bin` under `root` (test helper for the
+/// CLEAR-as-recovery scenario; avoids depending on the private SHA-256
+/// channel-hash routine that maps handlers to on-disk subdirectories).
+fn find_cursor_files(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+  let mut out = vec![];
+  let Ok(entries) = std::fs::read_dir(root) else {
+    return out;
+  };
+  for entry in entries.flatten() {
+    let path = entry.path();
+    if path.is_dir() {
+      let cursor = path.join("cursor.bin");
+      if cursor.is_file() {
+        out.push(cursor);
+      }
+      out.extend(find_cursor_files(&path));
+    }
+  }
+  out
+}
+
+/// PUSH N → CLEAR → GET_CHAN_LEN returns 0 → POP returns QUEUE_EMPTY → a
+/// fresh PUSH+POP cycle works (the queue is reusable after CLEAR, seq
+/// monotonicity holds).
+#[compio::test]
+async fn test_clear_semantics() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = FileMessageLogFactory::new(
+    tmp.path().to_path_buf(),
+    default_c2s_config().limits.max_payload_size,
+    MessageLogMetrics::noop(),
+  );
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  bootstrap_fifo(&mut suite, 10, None).await?;
+  push_ok(&mut suite, TEST_USER_1, CHANNEL, 1, b"one").await?;
+  push_ok(&mut suite, TEST_USER_1, CHANNEL, 2, b"two").await?;
+  push_ok(&mut suite, TEST_USER_1, CHANNEL, 3, b"three").await?;
+  assert_eq!(get_chan_len_ok(&mut suite, TEST_USER_1, CHANNEL, 4).await?, 3);
+
+  clear_ok(&mut suite, TEST_USER_1, CHANNEL, 5).await?;
+
+  assert_eq!(get_chan_len_ok(&mut suite, TEST_USER_1, CHANNEL, 6).await?, 0);
+
+  // POP must fail with QUEUE_EMPTY, not return any of the cleared entries.
+  suite.write_message(TEST_USER_1, Message::Pop(PopParameters { id: 7, channel: StringAtom::from(CHANNEL) })).await?;
+  match suite.read_message(TEST_USER_1).await? {
+    Message::Error(p) => assert_eq!(p.reason, StringAtom::from(ErrorReason::QueueEmpty)),
+    other => panic!("expected Error(QUEUE_EMPTY), got: {:?}", other),
+  }
+
+  // The queue remains usable after CLEAR: a fresh PUSH delivers cleanly.
+  push_ok(&mut suite, TEST_USER_1, CHANNEL, 8, b"fresh").await?;
+  let (payload, _) = pop_ok(&mut suite, TEST_USER_1, CHANNEL, 9).await?;
+  assert_eq!(payload, b"fresh");
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
+  Ok(())
+}
+
+/// CLEAR on an empty queue is a no-op that still ACKs; back-to-back CLEAR
+/// is the retry-on-missing-ACK case and must also succeed without side
+/// effects.
+#[compio::test]
+async fn test_clear_idempotence() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = FileMessageLogFactory::new(
+    tmp.path().to_path_buf(),
+    default_c2s_config().limits.max_payload_size,
+    MessageLogMetrics::noop(),
+  );
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  bootstrap_fifo(&mut suite, 10, None).await?;
+
+  clear_ok(&mut suite, TEST_USER_1, CHANNEL, 1).await?;
+  clear_ok(&mut suite, TEST_USER_1, CHANNEL, 2).await?;
+  assert_eq!(get_chan_len_ok(&mut suite, TEST_USER_1, CHANNEL, 3).await?, 0);
+
+  // After a PUSH+CLEAR, a second CLEAR is still a no-op ack.
+  push_ok(&mut suite, TEST_USER_1, CHANNEL, 4, b"x").await?;
+  clear_ok(&mut suite, TEST_USER_1, CHANNEL, 5).await?;
+  clear_ok(&mut suite, TEST_USER_1, CHANNEL, 6).await?;
+  assert_eq!(get_chan_len_ok(&mut suite, TEST_USER_1, CHANNEL, 7).await?, 0);
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
+  Ok(())
+}
+
+/// CLEAR authorization: non-owner member → FORBIDDEN; non-member auth'd
+/// client → USER_NOT_IN_CHANNEL; pub/sub channel → WRONG_TYPE.
+#[compio::test]
+async fn test_clear_authorization() -> anyhow::Result<()> {
+  let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+  let tmp = tempfile::tempdir()?;
+  let store = FileChannelStore::new(tmp.path().to_path_buf()).await?;
+  let mlf = FileMessageLogFactory::new(
+    tmp.path().to_path_buf(),
+    default_c2s_config().limits.max_payload_size,
+    MessageLogMetrics::noop(),
+  );
+
+  let mut suite = C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+  suite.setup().await?;
+
+  bootstrap_fifo(&mut suite, 10, None).await?;
+  suite.auth(TEST_USER_2, TEST_USER_2).await?;
+  suite.join_channel(TEST_USER_2, CHANNEL, None).await?;
+  // owner drains MEMBER_JOINED.
+  suite.ignore_reply(TEST_USER_1).await?;
+
+  // Non-owner CLEAR -> FORBIDDEN.
+  suite
+    .write_message(TEST_USER_2, Message::Clear(ClearParameters { id: 11, channel: StringAtom::from(CHANNEL) }))
+    .await?;
+  match suite.read_message(TEST_USER_2).await? {
+    Message::Error(p) => {
+      assert_eq!(p.id, Some(11));
+      assert_eq!(p.reason, StringAtom::from(ErrorReason::Forbidden));
+    },
+    other => panic!("expected Error(FORBIDDEN), got: {:?}", other),
+  }
+
+  // Non-member CLEAR -> USER_NOT_IN_CHANNEL. user_2 leaves first.
+  suite
+    .write_message(
+      TEST_USER_2,
+      Message::LeaveChannel(LeaveChannelParameters { id: 12, channel: StringAtom::from(CHANNEL), on_behalf: None }),
+    )
+    .await?;
+  match suite.read_message(TEST_USER_2).await? {
+    Message::LeaveChannelAck(p) => assert_eq!(p.id, 12),
+    other => panic!("expected LeaveChannelAck, got: {:?}", other),
+  }
+  // owner drains MEMBER_LEFT.
+  suite.ignore_reply(TEST_USER_1).await?;
+  suite
+    .write_message(TEST_USER_2, Message::Clear(ClearParameters { id: 13, channel: StringAtom::from(CHANNEL) }))
+    .await?;
+  match suite.read_message(TEST_USER_2).await? {
+    Message::Error(p) => {
+      assert_eq!(p.id, Some(13));
+      assert_eq!(p.reason, StringAtom::from(ErrorReason::UserNotInChannel));
+    },
+    other => panic!("expected Error(USER_NOT_IN_CHANNEL), got: {:?}", other),
+  }
+
+  // CLEAR on a pub/sub channel -> WRONG_TYPE.
+  let pubsub_channel = "!pubsub@localhost";
+  suite.join_channel(TEST_USER_1, pubsub_channel, None).await?;
+  suite
+    .write_message(TEST_USER_1, Message::Clear(ClearParameters { id: 14, channel: StringAtom::from(pubsub_channel) }))
+    .await?;
+  match suite.read_message(TEST_USER_1).await? {
+    Message::Error(p) => {
+      assert_eq!(p.id, Some(14));
+      assert_eq!(p.reason, StringAtom::from(ErrorReason::WrongType));
+    },
+    other => panic!("expected Error(WRONG_TYPE), got: {:?}", other),
+  }
+
+  suite.teardown().await?;
+  s2m_ln.shutdown().await?;
+  s2m_dispatcher.shutdown().await?;
+  Ok(())
+}
+
+/// CLEAR is the owner-driven recovery path for `CURSOR_RECOVERY_REQUIRED`.
+/// First boot: transition + PUSH + clean shutdown. Between boots, corrupt
+/// `cursor.bin` so recovery surfaces the channel as `NeedsRecovery`. Second
+/// boot: PUSH / POP / GET_CHAN_LEN must all reject with
+/// `CURSOR_RECOVERY_REQUIRED`, then CLEAR succeeds and brings the channel
+/// back to healthy (next PUSH+POP work).
+#[compio::test]
+async fn test_clear_as_recovery_path() -> anyhow::Result<()> {
+  let tmp = tempfile::tempdir()?;
+  let data_dir = tmp.path().to_path_buf();
+
+  // First boot: transition and PUSH some entries.
+  {
+    let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+    let store = FileChannelStore::new(data_dir.clone()).await?;
+    let mlf = FileMessageLogFactory::new(
+      data_dir.clone(),
+      default_c2s_config().limits.max_payload_size,
+      MessageLogMetrics::noop(),
+    );
+
+    let mut suite =
+      C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+    suite.setup().await?;
+
+    bootstrap_fifo(&mut suite, 10, None).await?;
+    push_ok(&mut suite, TEST_USER_1, CHANNEL, 1, b"alpha").await?;
+    push_ok(&mut suite, TEST_USER_1, CHANNEL, 2, b"beta").await?;
+
+    suite.teardown().await?;
+    s2m_ln.shutdown().await?;
+    s2m_dispatcher.shutdown().await?;
+  }
+
+  // Between boots: scramble cursor.bin. The CRC will fail to verify and
+  // the channel will come up in NeedsRecovery.
+  let cursor_files = find_cursor_files(&data_dir);
+  assert_eq!(cursor_files.len(), 1, "expected exactly one cursor.bin, found {:?}", cursor_files);
+  std::fs::write(&cursor_files[0], [0xFFu8; 16])?;
+
+  // Second boot: NeedsRecovery rejects FIFO data plane; CLEAR heals.
+  {
+    let (s2m_client, mut s2m_ln, mut s2m_dispatcher) = bootstrap_s2m(make_auth_modulator()).await?;
+    let store = FileChannelStore::new(data_dir.clone()).await?;
+    let mlf = FileMessageLogFactory::new(
+      data_dir.clone(),
+      default_c2s_config().limits.max_payload_size,
+      MessageLogMetrics::noop(),
+    );
+
+    let mut suite =
+      C2sSuite::with_modulator_and_stores(default_c2s_config(), Some(s2m_client), None, store, mlf).await?;
+    suite.setup().await?;
+
+    suite.auth(TEST_USER_1, TEST_USER_1).await?;
+
+    // PUSH, POP, GET_CHAN_LEN all reject with CURSOR_RECOVERY_REQUIRED.
+    write_push(&mut suite, TEST_USER_1, CHANNEL, 100, b"blocked").await?;
+    match suite.read_message(TEST_USER_1).await? {
+      Message::Error(p) => assert_eq!(p.reason, StringAtom::from(ErrorReason::CursorRecoveryRequired)),
+      other => panic!("expected Error(CURSOR_RECOVERY_REQUIRED), got: {:?}", other),
+    }
+    suite
+      .write_message(TEST_USER_1, Message::Pop(PopParameters { id: 101, channel: StringAtom::from(CHANNEL) }))
+      .await?;
+    match suite.read_message(TEST_USER_1).await? {
+      Message::Error(p) => assert_eq!(p.reason, StringAtom::from(ErrorReason::CursorRecoveryRequired)),
+      other => panic!("expected Error(CURSOR_RECOVERY_REQUIRED), got: {:?}", other),
+    }
+    suite
+      .write_message(
+        TEST_USER_1,
+        Message::GetChannelLen(GetChannelLenParameters { id: 102, channel: StringAtom::from(CHANNEL) }),
+      )
+      .await?;
+    match suite.read_message(TEST_USER_1).await? {
+      Message::Error(p) => assert_eq!(p.reason, StringAtom::from(ErrorReason::CursorRecoveryRequired)),
+      other => panic!("expected Error(CURSOR_RECOVERY_REQUIRED), got: {:?}", other),
+    }
+
+    // CLEAR heals: channel transitions back to Healthy.
+    clear_ok(&mut suite, TEST_USER_1, CHANNEL, 103).await?;
+
+    // After CLEAR, PUSH+POP work cleanly; the pre-corruption entries are
+    // gone (logically consumed) and a fresh PUSH is delivered.
+    push_ok(&mut suite, TEST_USER_1, CHANNEL, 104, b"after-heal").await?;
+    let (payload, _) = pop_ok(&mut suite, TEST_USER_1, CHANNEL, 105).await?;
+    assert_eq!(payload, b"after-heal");
 
     suite.teardown().await?;
     s2m_ln.shutdown().await?;

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -37,6 +37,8 @@
   - [POP_ACK](#pop_ack)
   - [GET_CHAN_LEN](#get_chan_len)
   - [CHAN_LEN](#chan_len)
+  - [CLEAR](#clear)
+  - [CLEAR_ACK](#clear_ack)
   - [MOD_DIRECT](#mod_direct)
   - [MOD_DIRECT_ACK](#mod_direct_ack)
   - [CHANNELS](#channels)
@@ -760,6 +762,47 @@ Returns the logical queue depth of a `fifo` channel.
 **Example**:
 ```
 CHAN_LEN id=9 channel=!queue@example.com count=42
+```
+
+---
+
+### CLEAR
+
+Discards every element currently queued on a `fifo` channel without destroying the channel. Owner-only, idempotent. Also the owner-driven recovery path for `CURSOR_RECOVERY_REQUIRED`.
+
+After `CLEAR_ACK`, `GET_CHAN_LEN` returns `0` and the next `POP` returns `QUEUE_EMPTY` until a fresh `PUSH` arrives. Channel membership, ACLs, and configuration are preserved. The seq counter is preserved as well: the next `PUSH` is assigned `log.last_seq() + 1`, so monotonicity holds across the operation (`CLEAR` does **not** reset seq to 1).
+
+**Direction**: Client → Server
+
+**Parameters**:
+- `id` (u32, required): Request identifier (must be non-zero)
+- `channel` (string, required): Target channel ID (must be non-empty)
+
+**Example**:
+```
+CLEAR id=10 channel=!queue@example.com
+```
+
+**Notes**:
+- Only valid on `fifo` channels. Returns `WRONG_TYPE` on a `pubsub` channel.
+- Caller must be the channel owner; non-owner members receive `FORBIDDEN`.
+- `CLEAR` is **not** rejected with `CURSOR_RECOVERY_REQUIRED`. When the head cursor failed recovery, `CLEAR` is the owner-driven heal path: the server flushes the log, writes a fresh `cursor.bin` with `next_seq = log.last_seq() + 1`, and transitions the channel from `NeedsRecovery` back to healthy.
+- Idempotent: clearing an already-empty queue succeeds with no externally visible effect. A producer retrying `CLEAR` on missing `CLEAR_ACK` cannot discard anything beyond what the original `CLEAR` would have.
+
+---
+
+### CLEAR_ACK
+
+Acknowledges a successful CLEAR. After this ACK the channel is healthy and the queue is empty.
+
+**Direction**: Server → Client
+
+**Parameters**:
+- `id` (u32, required): Request identifier matching the CLEAR message (must be non-zero)
+
+**Example**:
+```
+CLEAR_ACK id=10
 ```
 
 ---

--- a/docs/architecture/channels/fifo-channels.md
+++ b/docs/architecture/channels/fifo-channels.md
@@ -1,6 +1,6 @@
 # FIFO Channels: Architecture Specification
 
-> **Status:** Partially implemented (PUSH / POP / GET_CHAN_LEN; CLEAR pending PR 3).
+> **Status:** Implemented.
 > **Related design:** [Message Log](./message-log.md), [Channel Store](./channel-store.md)
 
 ## Table of Contents


### PR DESCRIPTION
## Summary

Closes out the FIFO v1 spec by adding `CLEAR` / `CLEAR_ACK`. Owner-only and idempotent: discards every queued element of a FIFO channel without destroying it. Channel membership, ACLs, configuration, and seq monotonicity are preserved — the next `PUSH` is assigned `log.last_seq() + 1`, not 1.

`CLEAR` doubles as the owner-driven recovery path for `CURSOR_RECOVERY_REQUIRED`. The handler is exempt from that error and uses the same crash-safe write order as the type-transition path:

1. Synchronously flush+fsync the log so `log.last_seq()` is anchored on disk.
2. Atomic-write `cursor.bin` with `next_seq = log.last_seq() + 1` (tmp → fsync → rename → fsync parent).
3. Install the fresh cursor; a `NeedsRecovery` channel transitions back to `Healthy` here.
4. Send `CLEAR_ACK`.
5. Best-effort lazy head-eviction below the new cursor.

After this PR, operators no longer need filesystem access to heal a corrupt cursor — the channel owner can do it via a single `CLEAR`.

## What changed

- **Protocol** (`crates/protocol`): `Clear` / `ClearAck` variants. Round-trip tests.
- **Channel manager** (`crates/server`): `Command::Clear` and matching handler with the full error matrix (`CHANNEL_NOT_FOUND`, `WRONG_TYPE`, `USER_NOT_IN_CHANNEL`, `FORBIDDEN`, `NOT_IMPLEMENTED` — **not** `CURSOR_RECOVERY_REQUIRED`). Public `clear()` mailbox wrapper.
- **C2S dispatch** (`crates/server/src/c2s/conn.rs`): wire `Message::Clear` to `dispatch_clear_message`.
- **Client** (`crates/client`): `clear(channel)` on both compio and tokio C2S clients.
- **Metrics**: `fifo_clears{result}` counter under the `narwhal` prefix, with labels `success`, `channel_not_found`, `user_not_in_channel`, `forbidden`, `wrong_type`, `not_implemented` (no `cursor_recovery_required` — CLEAR can't be rejected with that reason).
- **Docs**: `docs/PROTOCOL.md` gains `CLEAR` / `CLEAR_ACK` sections. `docs/architecture/channels/fifo-channels.md` status flips from "Partially implemented" to "Implemented". CHANGELOG entry now lists all three FIFO PRs (#292, #298, #299).

## Tests added

`crates/server/tests/c2s_fifo_channel.rs` gains 4 tests (27 total):

- **Semantics** — PUSH N → CLEAR → `GET_CHAN_LEN == 0` → next POP returns `QUEUE_EMPTY` → fresh PUSH+POP cycle works.
- **Idempotence** — back-to-back CLEAR on an empty queue both ACK without side effects; same after a PUSH+CLEAR pair.
- **Authorization** — non-owner CLEAR returns `FORBIDDEN`; non-member CLEAR returns `USER_NOT_IN_CHANNEL`; CLEAR on a `pubsub` channel returns `WRONG_TYPE`.
- **CLEAR-as-recovery** — first boot: transition + PUSH some entries + clean shutdown. Between boots: scramble `cursor.bin`. Second boot: `PUSH` / `POP` / `GET_CHAN_LEN` all reject with `CURSOR_RECOVERY_REQUIRED`. CLEAR then heals the channel (transitions back to `Healthy`); a follow-up PUSH+POP cycle works.

The recovery test uses a small `find_cursor_files()` helper that walks the temp dir for `cursor.bin` files (avoids depending on the private `channel_hash` SHA-256 routine).

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` passes (all tests green, including the 4 new CLEAR tests and the 23 prior FIFO tests)

## Spec status

With this PR the spec at `docs/architecture/channels/fifo-channels.md` flips to **Implemented**. Everything in the "Out of Scope (v1)" section (wake-on-push, at-least-once leases, server-side PUSH idempotency, batched POP, FIFO→pubsub reversion, shared ownership) remains deferred as designed.