### PR TITLE
chore: release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Narwhal will be documented in this file.
 
-## Unreleased
+## 0.7.0 (2026-05-15)
 
 * [ENHANCEMENT]: Add support for FIFO-type channels with at-most-once delivery via `PUSH` / `POP` / `GET_CHAN_LEN` / `CLEAR`. [#292](https://github.com/ortuman/narwhal/pull/292), [#298](https://github.com/ortuman/narwhal/pull/298), [#299](https://github.com/ortuman/narwhal/pull/299)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-benchmark"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-client"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-common"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-modulator"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-protocol"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-protocol-macros"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-server"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-test-util"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-util"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ To trade strict per-message durability for higher throughput, add `--flush-inter
 
 ## Project Status
 
-**Current Version: 0.6.1 (Alpha)**
+**Current Version: 0.7.0 (Alpha)**
 
 Narwhal is in active development and currently in **alpha** stage. While the core functionality is working and tested, please note:
 

--- a/crates/benchmark/Cargo.toml
+++ b/crates/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-benchmark"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-client"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-common"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/modulator/Cargo.toml
+++ b/crates/modulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-modulator"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/protocol-macros/Cargo.toml
+++ b/crates/protocol-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-protocol-macros"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-protocol"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-server"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/test-util/Cargo.toml
+++ b/crates/test-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-test-util"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narwhal-util"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/examples/modulator/Cargo.lock
+++ b/examples/modulator/Cargo.lock
@@ -176,7 +176,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "broadcast-payload-csv-validator"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "broadcast-payload-json-validator"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-client"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-common"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-modulator"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-protocol"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-protocol-macros"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "narwhal-util"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1303,7 +1303,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain-authenticator"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "private-payload-sender"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/examples/modulator/broadcast-payload-csv-validator/Cargo.toml
+++ b/examples/modulator/broadcast-payload-csv-validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "broadcast-payload-csv-validator"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/examples/modulator/broadcast-payload-json-validator/Cargo.toml
+++ b/examples/modulator/broadcast-payload-json-validator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "broadcast-payload-json-validator"
 description = "A JSON payload validator for Narwhal protocol"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/examples/modulator/plain-authenticator/Cargo.toml
+++ b/examples/modulator/plain-authenticator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plain-authenticator"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/examples/modulator/private-payload-sender/Cargo.toml
+++ b/examples/modulator/private-payload-sender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "private-payload-sender"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-3-Clause"
 


### PR DESCRIPTION
## Summary

- Cut the 0.7.0 release: promote the Unreleased CHANGELOG entry to `0.7.0 (2026-05-15)`, bump every crate and modulator example from 0.6.1 to 0.7.0, refresh both `Cargo.lock` files, and update the version badge in the README.
- Highlight for this release: FIFO-type channels with at-most-once delivery via `PUSH` / `POP` / `GET_CHAN_LEN` / `CLEAR` (#292, #298, #299).

## Test plan

- [x] `cargo check --workspace` (top-level)
- [x] `cargo check --workspace` (examples/modulator)
- [x] CI green on this PR